### PR TITLE
Adding dockerfiles and install scripts

### DIFF
--- a/admission-webhook/Makefile
+++ b/admission-webhook/Makefile
@@ -1,33 +1,9 @@
 .DEFAULT_GOAL := test
 SHELL := /bin/bash
 
-# path to glide, will be downloaded if needed
-GLIDE_BIN ?= $(shell which glide 2> /dev/null)
-ifeq ($(GLIDE_BIN),)
-GLIDE_BIN = $(GOPATH)/bin/glide
-endif
+include make/*.mk
 
+# the $GO_TEST_FLAGS env vars can be set to eg run only specific tests
 .PHONY: test
 test:
 	go test -v -count=1 -cover "$$GO_TEST_FLAGS"
-
-.PHONY: install_deps
-install_deps: $(GLIDE_BIN)
-	$(GLIDE_BIN) install -v
-
-.PHONY: update_deps
-update_deps: $(GLIDE_BIN)
-	$(GLIDE_BIN) update -v
-
-GLIDE_URL = https://glide.sh/get
-$(GLIDE_BIN):
-	@ if [ ! "$$GOPATH" ]; then \
-		echo "GOPATH env var not defined, cannot install glide"; \
-		exit 1; \
-	fi
-	mkdir -p $(dir $(GLIDE_BIN))
-	if which curl &> /dev/null; then \
-		curl $(GLIDE_URL) | sh; \
-	else \
-		wget -O - $(GLIDE_URL) 2> /dev/null | sh; \
-	fi

--- a/admission-webhook/README.md
+++ b/admission-webhook/README.md
@@ -1,0 +1,13 @@
+# Windows GMSA Webhook Admission controller
+
+## How to deploy
+
+Assuming that `kubectl` is in your path and that your cluster's kube admin config file is present at either the canonical location
+(`~/.kube/config`) or at the path specified by the `KUBECONFIG` environment variable, simply run:
+```bash
+curl -sL https://raw.githubusercontent.com/kubernetes-sigs/windows-gmsa/master/admission-webhook/deploy/deploy-gmsa-webhook.sh | bash -s -- --file webhook-manifests.yml
+```
+
+Run with the `--dry-run` option to not change anything to your cluster just yet and simply review the change it would be doing.
+
+Run with `--help` to see all the available options.

--- a/admission-webhook/deploy/.helpers.sh
+++ b/admission-webhook/deploy/.helpers.sh
@@ -1,0 +1,62 @@
+## Meant to be sourced by other files in this repo
+
+echo_stderr() {
+    local COLOR
+    local NO_COLOR='\033[0m'
+
+    case "$1" in
+        green)
+            COLOR='\033[0;32m' ;;
+        yellow)
+            COLOR='\033[0;33m' ;;
+        red)
+            COLOR='\033[0;31m' ;;
+        esac
+    shift 1
+
+    >&2 printf "${COLOR}$@\n${NO_COLOR}"
+}
+
+info() {
+    echo_stderr 'green' "*** $@ ***"
+}
+
+warn() {
+    echo_stderr 'yellow' "WARNING: $@"
+}
+
+fatal_error() {
+    echo_stderr 'red' "FATAL ERROR: $@"
+    exit 1
+}
+
+if [ ! "$KUBECTL" ]; then
+    KUBECTL=$(which kubectl)
+fi
+if [ ! -x "$KUBECTL" ]; then
+    fatal_error 'kubectl not found'
+fi
+
+echo_or_run() {
+    local WITH_KUBECTL_DRY_RUN=false
+    if [[ "$1" == '--with-kubectl-dry-run' ]]; then
+        WITH_KUBECTL_DRY_RUN=true
+        shift
+    fi
+
+    if $DRY_RUN; then
+        echo "$@"
+        if $WITH_KUBECTL_DRY_RUN; then
+            eval "$@ --dry-run >&2"
+        fi
+    else
+        eval "$@"
+    fi
+}
+
+SERVER_KEY="$CERTS_DIR/server-key.pem"
+SERVER_CERT="$CERTS_DIR/server-cert.pem"
+
+if [ "$K8S_WINDOWS_GMSA_DEPLOY_DEBUG" ]; then
+    set -x
+fi

--- a/admission-webhook/deploy/create-signed-cert.sh
+++ b/admission-webhook/deploy/create-signed-cert.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+## Generates cluster-valid SSL certs for the webhook service
+## Inspired from
+## https://raw.githubusercontent.com/istio/istio/release-0.7/install/kubernetes/webhook-create-signed-cert.sh
+## whose license is also Apache 2.0
+
+set -e
+
+usage() {
+    cat <<EOF
+Generates certificate suitable for use with the GMSA webhook service.
+
+This script uses k8s' CertificateSigningRequest API to a generate a
+certificate signed by k8s CA suitable for use with the GMSA webhook
+service. This requires permissions to create and approve CSR. See
+https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster for
+detailed explantion and additional instructions.
+
+usage: $0 --service SERVICE_NAME --namespace NAMESPACE_NAME --certs-dir PATH/TO/CERTS/DIR [--dry-run] [--overwrite]
+
+If --dry-run is set, the script echoes what command it would perform
+to stdout without actually affecting the k8s cluster.
+If the files this script generates already exist and --overwrite is
+not set, it will not regenerate the files.
+EOF
+    exit 1
+}
+
+SERVICE=
+NAMESPACE=
+CERTS_DIR=
+DRY_RUN=false
+OVERWRITE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --service)
+            SERVICE="$2" && shift 2 ;;
+        --namespace)
+            NAMESPACE="$2" && shift 2 ;;
+        --certs-dir)
+            CERTS_DIR="$2" && shift 2 ;;
+        --dry-run)
+            DRY_RUN=true && shift ;;
+        --overwrite)
+            OVERWRITE=true && shift ;;
+        *)
+            usage ;;
+    esac
+done
+
+[ "$SERVICE" ] && [ "$NAMESPACE" ] && [ "$CERTS_DIR" ] || usage
+
+if [ ! "$K8S_WINDOWS_GMSA_HELPER_SCRIPT" ]; then
+    DEPLOY_DIR="$(dirname "$0")"
+    K8S_WINDOWS_GMSA_HELPER_SCRIPT="$DEPLOY_DIR/.helpers.sh"
+fi
+. "$K8S_WINDOWS_GMSA_HELPER_SCRIPT"
+
+if [ ! -x "$(command -v openssl)" ]; then
+    fatal_error 'openssl not found'
+fi
+
+wait_for() {
+    local FUN="$1"
+    local ERROR_MSG="$2"
+    local MAX_ATTEMPTS="$3"
+    [ "$MAX_ATTEMPTS" ] || MAX_ATTEMPTS=30
+
+    local OUTPUT
+    for _ in $(seq "$MAX_ATTEMPTS"); do
+        if OUTPUT=$($FUN); then
+            echo "$OUTPUT"
+            return
+        fi
+        sleep 1
+    done
+
+    fatal_error "$ERROR_MSG, giving up after $MAX_ATTEMPTS attempts"
+}
+
+gen_file() {
+    local FUN="$1"
+    local FILE_PATH="$2"
+
+    if [ -f "$FILE_PATH" ] && ! $OVERWRITE; then
+        warn "$FILE_PATH already exists, not re-generating"
+    else
+        $FUN
+    fi
+}
+
+gen_server_key() { openssl genrsa -out "$SERVER_KEY" 2048; }
+gen_file gen_server_key "$SERVER_KEY"
+
+CSR_CONF="$CERTS_DIR/csr.conf"
+gen_csr_conf() {
+    cat <<EOF >> "$CSR_CONF"
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = $SERVICE
+DNS.2 = $SERVICE.$NAMESPACE
+DNS.3 = $SERVICE.$NAMESPACE.svc
+EOF
+}
+gen_file gen_csr_conf "$CSR_CONF"
+
+SERVER_CSR="$CERTS_DIR/server.csr"
+gen_server_scr() { openssl req -new -key "$SERVER_KEY" -subj "/CN=$SERVICE.$NAMESPACE.svc" -out "$SERVER_CSR" -config "$CSR_CONF"; }
+gen_file gen_server_scr "$SERVER_CSR"
+
+CSR_NAME="$SERVICE.$NAMESPACE"
+# clean-up any previously created CSR for our service
+if ! $DRY_RUN && $KUBECTL get csr "$CSR_NAME" &> /dev/null; then
+    $KUBECTL delete csr "$CSR_NAME"
+fi
+
+# create  server cert/key CSR and  send to k8s API
+CSR_CONTENTS=$(cat <<EOF
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: $CSR_NAME
+spec:
+  groups:
+  - system:authenticated
+  request: $(cat "$SERVER_CSR" | base64 -w 0)
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+)
+echo_or_run --with-kubectl-dry-run "$KUBECTL create -f - <<< '$CSR_CONTENTS'"
+
+if ! $DRY_RUN; then
+    verify_csr_created() { $KUBECTL get csr "$CSR_NAME"; }
+    wait_for verify_csr_created "CSR $CSR_NAME not properly created"
+fi
+
+# approve and fetch the signed certificate
+echo_or_run "$KUBECTL certificate approve $CSR_NAME"
+
+if ! $DRY_RUN; then
+    verify_cert_signed() {
+        local CERT_CONTENTS
+        CERT_CONTENTS=$($KUBECTL get csr $CSR_NAME -o jsonpath='{.status.certificate}')
+        echo "$CERT_CONTENTS"
+        [[ "$CERT_CONTENTS" != "" ]]
+    }
+    SERVER_CERT_CONTENTS=$(wait_for verify_cert_signed "after approving CSR $CSR_NAME, the signed certificate did not appear on the resource")
+
+    gen_server_cert() { echo "$SERVER_CERT_CONTENTS" | openssl base64 -d -A -out "$SERVER_CERT"; }
+    gen_file gen_server_cert "$SERVER_CERT"
+fi

--- a/admission-webhook/deploy/deploy-gmsa-webhook.sh
+++ b/admission-webhook/deploy/deploy-gmsa-webhook.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+## Deploys the GMSA webhook
+
+set -e
+
+usage() {
+    cat <<EOF
+Deploys the GMSA webhook.
+
+Should be run with a kube admin config file present at either the canonical location
+(~/.kube/config) or at the path specified by the KUBECONFIG environment variable.
+
+This script:
+ * generates a SSL certificate signed by k8s, for mutual authentication
+   between the API server and the webhook service
+ * deploys a k8s service running the webhook
+ * registers that service as a webhook admission controller
+
+usage: $0 --file MANIFESTS_FILE [--name NAME] [--namespace NAMESPACE] [--image IMAGE_NAME] [--certs-dir CERTS_DIR] [--dry-run] [--overwrite]
+
+MANIFESTS_FILE is the path to the file where the k8s manifests will be written
+NAME defaults to 'gsma-webhook' and is used in the names of most the k8s resources created.
+NAMESPACE is the namespace to deploy to; defaults to 'gmsa-webhook' - will error out if the namespace already exists.
+IMAGE_NAME is the name of the Docker image containing the webhook; defaults to 'wk88/k8s-gmsa-webhook:latest' (FIXME: figure out a better way to distribute this image)
+CERTS_DIR defaults to 'gmsa-webhook-certs'
+
+If --dry-run is set, the script echoes what command it would perform
+without actually affecting the k8s cluster.
+If the files this script generates already exist and --overwrite is
+not set, it will not regenerate the files.
+EOF
+    exit 1
+}
+
+DEPLOY_DIR="$(dirname "$0")"
+TMP_DIR_PREFIX='/tmp/gmsa-webhook-deploy-'
+
+ensure_helper_file_present() {
+    local NAME="$1"
+    local DIR="$DEPLOY_DIR"
+
+    if [ ! -r "$DIR/$NAME" ]; then
+        DIR=$(mktemp -d "${TMP_DIR_PREFIX}XXXXXXX")
+        local URL="https://raw.githubusercontent.com/kubernetes-sigs/windows-gmsa/master/admission-webhook/deploy/$NAME"
+
+        if which curl &> /dev/null; then
+            curl -sL "$URL" > "$DIR/$NAME"
+        else
+            wget -O "$DIR/$NAME" "$URL"
+        fi
+    fi
+
+    echo "$DIR/$NAME"
+}
+
+main() {
+    local MANIFESTS_FILE=
+    local NAME='gmsa-webhook'
+    local NAMESPACE='gmsa-webhook'
+    local IMAGE_NAME='wk88/k8s-gmsa-webhook:latest'
+    local CERTS_DIR='gmsa-webhook-certs'
+    local DRY_RUN=false
+    local OVERWRITE=false
+
+    # parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --file)
+                MANIFESTS_FILE="$2" && shift 2 ;;
+            --name)
+                NAME="$2" && shift 2 ;;
+            --namespace)
+                NAMESPACE="$2" && shift 2 ;;
+            --image-name)
+                IMAGE_NAME="$2" && shift 2 ;;
+            --certs-dir)
+                CERTS_DIR="$2" && shift 2 ;;
+            --dry-run)
+                DRY_RUN=true && shift ;;
+            --overwrite)
+                OVERWRITE=true && shift ;;
+            *)
+                usage ;;
+        esac
+    done
+
+    [ "$MANIFESTS_FILE" ] || usage
+
+    # download the helper scripts if needed
+    local HELPERS_SCRIPT
+    HELPER_SCRIPT=$(ensure_helper_file_present '.helpers.sh')
+    . "$HELPER_SCRIPT"
+    local CREATE_SIGNED_CERT_SCRIPT
+    CREATE_SIGNED_CERT_SCRIPT=$(ensure_helper_file_present 'create-signed-cert.sh')
+
+    if [ ! -x "$(command -v envsubst)" ]; then
+        fatal_error 'envsubst not found'
+    fi
+
+    if [ -d "$CERTS_DIR" ]; then
+        $OVERWRITE || warn "Certs dir $CERTS_DIR already exists"
+    else
+        mkdir -p "$CERTS_DIR"
+    fi
+
+    # create the SSL cert and apply it to the cluster
+    local CREATE_CERT_CMD="$BASH $CREATE_SIGNED_CERT_SCRIPT --service $NAME --namespace $NAMESPACE --certs-dir $CERTS_DIR"
+    $DRY_RUN && CREATE_CERT_CMD+=" --dry-run" || true
+    $OVERWRITE && CREATE_CERT_CMD+=" --overwrite" || true
+    eval "K8S_WINDOWS_GMSA_HELPER_SCRIPT='$HELPER_SCRIPT' $CREATE_CERT_CMD"
+
+    # then render the template for the rest of the resources
+    local TEMPLATE_PATH
+    TEMPLATE_PATH=$(ensure_helper_file_present 'gmsa-webhook.yml.tpl')
+
+    # the TLS certificate might not have been generated yet if it's a dry run
+    local TLS_CERTIFICATE
+    if [ -r "$SERVER_CERT" ]; then
+        TLS_CERTIFICATE=$(cat "$SERVER_CERT" | base64 -w 0)
+    elif $DRY_RUN; then
+        TLS_CERTIFICATE='TBD'
+    else
+        fatal_error "Expected to find the server certificate at $SERVER_CERT"
+    fi
+
+    TLS_PRIVATE_KEY=$(cat "$SERVER_KEY" | base64 -w 0) \
+        TLS_CERTIFICATE="$TLS_CERTIFICATE" \
+        CA_BUNDLE="$($KUBECTL get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 -w 0)" \
+        RBAC_ROLE_NAME="$NAMESPACE-$NAME-rbac-role" \
+        NAME="$NAME" \
+        NAMESPACE="$NAMESPACE" \
+        IMAGE_NAME="$IMAGE_NAME" \
+        envsubst < "$TEMPLATE_PATH" > "$MANIFESTS_FILE"
+
+    echo_or_run --with-kubectl-dry-run "$KUBECTL apply -f $MANIFESTS_FILE"
+
+    if ! $DRY_RUN; then
+        info 'Windows GMSA Admission Webhook successfully deployed!'
+        info "You can remove it by running $KUBECTL delete -f $MANIFESTS_FILE"
+    fi
+
+    # cleanup
+    rm -rf "$TMP_DIR_PREFIX"*
+}
+
+main "$@"

--- a/admission-webhook/deploy/gmsa-webhook.yml.tpl
+++ b/admission-webhook/deploy/gmsa-webhook.yml.tpl
@@ -1,0 +1,197 @@
+## Template to deploy the GMSA webhook
+## TODO: make this a helmchart instead?
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NAMESPACE}
+  labels:
+    gmsa-webhook: disabled
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${NAME}
+  namespace: ${NAMESPACE}
+data:
+  tls_private_key: ${TLS_PRIVATE_KEY}
+  tls_certificate: ${TLS_CERTIFICATE}
+
+---
+
+# the service account for the webhook
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAME}
+  namespace: ${NAMESPACE}
+
+---
+
+# the RBAC role that the webhook needs to:
+#  * read GMSA custom resources
+#  * check authorizations to use GMSA cred specs
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${RBAC_ROLE_NAME}
+rules:
+- apiGroups: ["windows.k8s.io"]
+  resources: ["gmsacredentialspecs"]
+  verbs: ["get"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["localsubjectaccessreviews"]
+  verbs: ["create"]
+
+---
+
+# bind that role to the webhook's service account
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${NAMESPACE}-${NAME}-binding-to-${RBAC_ROLE_NAME}
+  namespace: ${NAMESPACE}
+subjects:
+- kind: ServiceAccount
+  name: ${NAME}
+  namespace: ${NAMESPACE}
+roleRef:
+  kind: ClusterRole
+  name: ${RBAC_ROLE_NAME}
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${NAME}
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${NAME}
+  template:
+    metadata:
+      labels:
+        app: ${NAME}
+    spec:
+      serviceAccountName: ${NAME}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+      - name: ${NAME}
+        image: ${IMAGE_NAME}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 443
+        volumeMounts:
+          - name: tls
+            mountPath: "/tls"
+            readOnly: true
+        env:
+          - name: TLS_KEY
+            value: /tls/key
+          - name: TLS_CRT
+            value: /tls/crt
+      volumes:
+      - name: tls
+        secret:
+          secretName: ${NAME}
+          items:
+          - key: tls_private_key
+            path: key
+          - key: tls_certificate
+            path: crt
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${NAME}
+  namespace: ${NAMESPACE}
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    app: ${NAME}
+
+---
+
+# declare the CRD to be used
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: gmsacredentialspecs.windows.k8s.io
+spec:
+  group: windows.k8s.io
+  version: v1alpha1
+  names:
+    kind: GMSACredentialSpec
+    plural: gmsacredentialspecs
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        credspec:
+          description: GMSA Credential Spec
+          type: object
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: ${NAME}
+webhooks:
+- name: admission-webhook.windows-gmsa.sigs.k8s.io
+  clientConfig:
+    service:
+      name: ${NAME}
+      namespace: ${NAMESPACE}
+      path: "/validate"
+    caBundle: ${CA_BUNDLE}
+  rules:
+  - operations: ["CREATE", "UPDATE"]
+    apiGroups: [""]
+    apiVersions: ["*"]
+    resources: ["pods"]
+  failurePolicy: Fail
+  # don't run on ${NAMESPACE}
+  namespaceSelector:
+    matchExpressions:
+      - key: gmsa-webhook
+        operator: NotIn
+        values: [disabled]
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: ${NAME}
+webhooks:
+- name: admission-webhook.windows-gmsa.sigs.k8s.io
+  clientConfig:
+    service:
+      name: ${NAME}
+      namespace: ${NAMESPACE}
+      path: "/mutate"
+    caBundle: ${CA_BUNDLE}
+  rules:
+  - operations: ["CREATE"]
+    apiGroups: [""]
+    apiVersions: ["*"]
+    resources: ["pods"]
+  failurePolicy: Fail
+  # don't run on ${NAMESPACE}
+  namespaceSelector:
+    matchExpressions:
+    - key: gmsa-webhook
+      operator: NotIn
+      values: [disabled]

--- a/admission-webhook/dockerfiles/Dockerfile
+++ b/admission-webhook/dockerfiles/Dockerfile
@@ -1,0 +1,25 @@
+## Dockerfile for release, as lightweight as possible
+
+ARG GO_VERSION
+FROM golang:${GO_VERSION} AS builder
+
+WORKDIR /go/src/sigs.k8s.io/windows-gmsa/admission-webhook
+
+# copy go dependencies
+COPY /vendor ./vendor
+
+# build
+COPY *.go ./
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s"
+
+###
+
+FROM scratch
+
+WORKDIR /admission-webhook
+
+ENV LOG_LEVEL=info
+
+COPY --from=builder /go/src/sigs.k8s.io/windows-gmsa/admission-webhook/admission-webhook .
+
+ENTRYPOINT ["/admission-webhook/admission-webhook"]

--- a/admission-webhook/dockerfiles/Dockerfile.dev
+++ b/admission-webhook/dockerfiles/Dockerfile.dev
@@ -1,0 +1,29 @@
+## Dockerfile for dev
+## Differs from the release Dockerfile in that it allows re-compiling and re-starting
+## the webserver from within the container
+
+ARG GO_VERSION
+FROM golang:$GO_VERSION
+
+# we use runit so that we can stop the service without killing the container, and consequently
+# play around with it
+RUN apt-get update && apt-get install --yes runit
+RUN mkdir /etc/service/webhook \
+    && /bin/bash -c "echo -e '"'#!/bin/bash\nexec /go/src/sigs.k8s.io/windows-gmsa/admission-webhook/admission-webhook 2>&1\n'"' > /etc/service/webhook/run" \
+    && chmod +x /etc/service/webhook/run
+RUN ln -s /usr/bin/sv /etc/init.d/webhook
+
+WORKDIR /go/src/sigs.k8s.io/windows-gmsa/admission-webhook
+
+# copy go dependencies
+COPY /vendor ./vendor
+
+# build
+COPY *.go ./
+RUN go build
+
+# copy the rest
+COPY . .
+
+# let runit work its magic
+CMD ["runsvdir", "/etc/service"]

--- a/admission-webhook/main.go
+++ b/admission-webhook/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+)
+
+func main() {
+	initLogrus()
+
+	kubeClient, err := createKubeClient()
+	if err != nil {
+		panic(err)
+	}
+
+	webhook := newWebhook(kubeClient)
+
+	tlsConfig := &tlsConfig{
+		crtPath: env("TLS_CRT"),
+		keyPath: env("TLS_KEY"),
+	}
+
+	if err = webhook.start(443, tlsConfig, nil); err != nil {
+		panic(err)
+	}
+}
+
+var logLevels = map[string]logrus.Level{
+	"panic": logrus.PanicLevel,
+	"fatal": logrus.FatalLevel,
+	"error": logrus.ErrorLevel,
+	"warn":  logrus.WarnLevel,
+	"info":  logrus.InfoLevel,
+	"debug": logrus.DebugLevel,
+	"trace": logrus.TraceLevel,
+}
+
+func initLogrus() {
+	logrus.SetOutput(os.Stdout)
+
+	logLevel := logrus.DebugLevel
+	invalid := false
+
+	rawLogLevel, present := os.LookupEnv("LOG_LEVEL")
+	if present {
+		if level, valid := logLevels[strings.ToLower(rawLogLevel)]; valid {
+			logLevel = level
+		} else {
+			invalid = true
+		}
+	}
+
+	logrus.SetLevel(logLevel)
+
+	if invalid {
+		keys := make([]string, len(logLevels))
+		i := 0
+		for key := range logLevels {
+			keys[i] = key
+			i++
+		}
+		logrus.Warningf("Unknown log level %s, valid log levels are: %v", rawLogLevel, strings.Join(keys, ", "))
+	}
+}
+
+func createKubeClient() (*kubeClient, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return newKubeClient(config)
+}
+
+func env(key string) string {
+	if value, found := os.LookupEnv(key); found {
+		return value
+	}
+	panic(fmt.Errorf("%s env var not found", key))
+}

--- a/admission-webhook/make/deps.mk
+++ b/admission-webhook/make/deps.mk
@@ -1,0 +1,26 @@
+# path to glide, will be downloaded if needed
+GLIDE_BIN ?= $(shell which glide 2> /dev/null)
+ifeq ($(GLIDE_BIN),)
+GLIDE_BIN = $(GOPATH)/bin/glide
+endif
+
+.PHONY: deps_install
+deps_install: $(GLIDE_BIN)
+	$(GLIDE_BIN) install -v
+
+.PHONY: deps_update
+deps_update: $(GLIDE_BIN)
+	$(GLIDE_BIN) update -v
+
+GLIDE_URL = https://glide.sh/get
+$(GLIDE_BIN):
+	@ if [ ! "$$GOPATH" ]; then \
+		echo "GOPATH env var not defined, cannot install glide"; \
+		exit 1; \
+	fi
+	mkdir -p $(dir $(GLIDE_BIN))
+	if which curl &> /dev/null; then \
+		curl $(GLIDE_URL) | sh; \
+	else \
+		wget -O - $(GLIDE_URL) 2> /dev/null | sh; \
+	fi

--- a/admission-webhook/make/image.mk
+++ b/admission-webhook/make/image.mk
@@ -1,0 +1,18 @@
+GO_VERSION = 1.11.5
+DOCKER_BUILD = docker build . --build-arg GO_VERSION=$(GO_VERSION)
+
+DEV_IMAGE_NAME = k8s-windows-gmsa-webhook-dev
+# FIXME: find a better way to distribute/publish this image
+IMAGE_NAME = wk88/k8s-gmsa-webhook:latest
+
+.PHONY: image_build_dev
+image_build_dev:
+	$(DOCKER_BUILD) -f dockerfiles/Dockerfile.dev -t $(DEV_IMAGE_NAME)
+
+.PHONY: image_build
+image_build:
+	$(DOCKER_BUILD) -f dockerfiles/Dockerfile -t $(IMAGE_NAME)
+
+.PHONY: image_push
+image_push:
+	docker push $(IMAGE_NAME)


### PR DESCRIPTION
There are two dockerfiles: the one that will be shipped is as lean as
possible, while the one meant for development aims to make devs' lives'
easier.

Also adding install scripts that perform all the necessary steps to
deploy the webhook.

Not including any tests for now; all that will be used by integration
tests in the next PR.
(did test manually though)