### PR TITLE
Adding extensive integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
 language: go
 
+# must stay consistent with make/image.mk's GO_VERSION
 go:
   - 1.12
+
+env:
+  - T=unit
+  - T=integration KUBERNETES_VERSION=1.11
+  - T=integration KUBERNETES_VERSION=1.12
+  - T=integration KUBERNETES_VERSION=1.13
+  - T=integration DEPLOY_METHOD=download
+  - T=integration WITH_DEV_IMAGE=1
 
 install:
   - curl https://glide.sh/get | sh
@@ -13,4 +22,4 @@ cache:
     - ~/.glide
 
 script:
-  - cd $TRAVIS_BUILD_DIR/admission-webhook && make test
+  - cd $TRAVIS_BUILD_DIR/admission-webhook && ./.travis.sh

--- a/admission-webhook/.gitignore
+++ b/admission-webhook/.gitignore
@@ -1,1 +1,3 @@
+/dev/
+/integration_tests/tmp/
 /vendor/

--- a/admission-webhook/.travis.sh
+++ b/admission-webhook/.travis.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+## Runs the right Travis tests depending on the environment variables.
+## Must stay in syncs with the build matrix from .travis.yml
+
+set -e
+
+function run_integration_tests() {
+    if [[ "$DEPLOY_METHOD" == 'download' ]]; then
+        export K8S_GMSA_DEPLOY_METHOD='download'
+
+        if [ "$TRAVIS_COMMIT" ] && [ "$TRAVIS_PULL_REQUEST_SHA" ]; then
+            # it's a pull request
+            export K8S_GMSA_DEPLOY_DOWNLOAD_REPO="$TRAVIS_PULL_REQUEST_SLUG"
+            export K8S_GMSA_DEPLOY_DOWNLOAD_REV="$TRAVIS_PULL_REQUEST_SHA"
+        else
+            # not a pull request
+            export K8S_GMSA_DEPLOY_DOWNLOAD_REV="$(git rev-parse HEAD)"
+        fi
+    fi
+
+    export DEPLOYMENT_NAME=windows-gmsa-dev
+    export NAMESPACE=windows-gmsa-dev
+
+    if [ "$WITH_DEV_IMAGE" ]; then
+        make integration_tests_with_dev_image
+
+        # for good measure let's check that one can change and restart the webhook when using the dev image
+        local KUBECTL=~/.kubeadm-dind-cluster/kubectl
+        local BOGUS_VERSION='cannotbeavalidversion'
+
+        local POD_NAME
+        POD_NAME="$($KUBECTL -n "$NAMESPACE" get pod --selector=app=$DEPLOYMENT_NAME -o=jsonpath='{.items[0].metadata.name}')"
+        $KUBECTL -n "$NAMESPACE" exec "$POD_NAME" -- go build -ldflags="-X main.version=$BOGUS_VERSION"
+        $KUBECTL -n "$NAMESPACE" exec "$POD_NAME" -- service webhook restart
+
+        local SERVICE_IP
+        SERVICE_IP="$($KUBECTL -n $NAMESPACE get service $DEPLOYMENT_NAME -o=jsonpath='{.spec.clusterIP}')"
+
+        local INFO_OUTPUT
+        INFO_OUTPUT="$(docker exec kube-master curl -sk https://$SERVICE_IP/info)"
+
+        if [[ "$INFO_OUTPUT" == *"$BOGUS_VERSION"* ]]; then
+            echo -e "Output from /info does contain '$BOGUS_VERSION':\n$INFO_OUTPUT"
+        else
+            echo -e "Expected output from /info to contain '$BOGUS_VERSION', instead got:\n$INFO_OUTPUT"
+            exit 1
+        fi
+    else
+        make integration_tests
+    fi
+}
+
+case "$T" in
+    unit)
+        make unit_tests ;;
+    integration)
+        run_integration_tests ;;
+    *)
+        echo "Unknown test option: $T" && exit 1 ;;
+esac

--- a/admission-webhook/Makefile
+++ b/admission-webhook/Makefile
@@ -1,9 +1,42 @@
 .DEFAULT_GOAL := test
 SHELL := /bin/bash
 
+DEV_IMAGE_NAME = k8s-windows-gmsa-webhook-dev
+# FIXME: find a better way to distribute/publish this image
+IMAGE_NAME = wk88/k8s-gmsa-webhook:latest
+
+CURL = $(shell which curl 2> /dev/null)
+WGET = $(shell which wget 2> /dev/null)
+
+ifeq ($(CURL)$(WGET),)
+$(error "Neither curl nor wget available")
+endif
+
 include make/*.mk
 
-# the $GO_TEST_FLAGS env vars can be set to eg run only specific tests
 .PHONY: test
-test:
-	go test -v -count=1 -cover "$$GO_TEST_FLAGS"
+test: unit_tests integration_tests
+
+# the $UNIT_TEST_FLAGS env var can be set to eg run only specific tests
+.PHONY: unit_tests
+unit_tests:
+	go test -v -count=1 -cover "$$UNIT_TEST_FLAGS"
+
+.PHONY: integration_tests
+integration_tests: image_build deploy_webhook run_integration_tests
+
+.PHONY: integration_tests_with_dev_image
+integration_tests_with_dev_image: image_build_dev deploy_dev_webhook run_integration_tests
+
+# the $INTEGRATION_TEST_FLAGS env var can be set to eg run only specific tests
+.PHONY: run_integration_tests
+run_integration_tests:
+	echo "### Starting integration tests with Kubernetes version: $(KUBERNETES_VERSION) ###"
+	cd integration_tests && KUBECTL=$(KUBECTL) go test -count 1 -v "$$INTEGRATION_TEST_FLAGS"
+
+.PHONY: clean_integration_tests
+clean_integration_tests:
+	rm -rf integration_tests/tmp
+
+.PHONY: clean
+clean: clean_cluster clean_integration_tests

--- a/admission-webhook/deploy/.helpers.sh
+++ b/admission-webhook/deploy/.helpers.sh
@@ -31,9 +31,9 @@ fatal_error() {
 }
 
 if [ ! "$KUBECTL" ]; then
-    KUBECTL=$(which kubectl)
+    KUBECTL=$(which kubectl) || true
 fi
-if [ ! -x "$KUBECTL" ]; then
+if [ ! -x $KUBECTL ]; then
     fatal_error 'kubectl not found'
 fi
 
@@ -52,6 +52,24 @@ echo_or_run() {
     else
         eval "$@"
     fi
+}
+
+wait_for() {
+    local FUN="$1"
+    local ERROR_MSG="$2"
+    local MAX_ATTEMPTS="$3"
+    [ "$MAX_ATTEMPTS" ] || MAX_ATTEMPTS=30
+
+    local OUTPUT
+    for _ in $(seq "$MAX_ATTEMPTS"); do
+        if OUTPUT=$($FUN); then
+            echo "$OUTPUT"
+            return
+        fi
+        sleep 1
+    done
+
+    fatal_error "$ERROR_MSG, giving up after $MAX_ATTEMPTS attempts - last attempt's output: $OUTPUT"
 }
 
 SERVER_KEY="$CERTS_DIR/server-key.pem"

--- a/admission-webhook/deploy/create-signed-cert.sh
+++ b/admission-webhook/deploy/create-signed-cert.sh
@@ -46,6 +46,7 @@ while [[ $# -gt 0 ]]; do
         --overwrite)
             OVERWRITE=true && shift ;;
         *)
+            echo "Unknown option: $1"
             usage ;;
     esac
 done
@@ -61,24 +62,6 @@ fi
 if [ ! -x "$(command -v openssl)" ]; then
     fatal_error 'openssl not found'
 fi
-
-wait_for() {
-    local FUN="$1"
-    local ERROR_MSG="$2"
-    local MAX_ATTEMPTS="$3"
-    [ "$MAX_ATTEMPTS" ] || MAX_ATTEMPTS=30
-
-    local OUTPUT
-    for _ in $(seq "$MAX_ATTEMPTS"); do
-        if OUTPUT=$($FUN); then
-            echo "$OUTPUT"
-            return
-        fi
-        sleep 1
-    done
-
-    fatal_error "$ERROR_MSG, giving up after $MAX_ATTEMPTS attempts"
-}
 
 gen_file() {
     local FUN="$1"

--- a/admission-webhook/deploy/gmsa-webhook.yml.tpl
+++ b/admission-webhook/deploy/gmsa-webhook.yml.tpl
@@ -86,6 +86,11 @@ spec:
       - name: ${NAME}
         image: ${IMAGE_NAME}
         imagePullPolicy: IfNotPresent
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /health
+            port: 443
         ports:
         - containerPort: 443
         volumeMounts:

--- a/admission-webhook/dockerfiles/Dockerfile
+++ b/admission-webhook/dockerfiles/Dockerfile
@@ -10,7 +10,8 @@ COPY /vendor ./vendor
 
 # build
 COPY *.go ./
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s"
+ARG VERSION
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -X main.version=${VERSION}"
 
 ###
 

--- a/admission-webhook/dockerfiles/Dockerfile.dev
+++ b/admission-webhook/dockerfiles/Dockerfile.dev
@@ -20,7 +20,8 @@ COPY /vendor ./vendor
 
 # build
 COPY *.go ./
-RUN go build
+ARG VERSION
+RUN go build -ldflags="-X main.version=${VERSION}"
 
 # copy the rest
 COPY . .

--- a/admission-webhook/glide.lock
+++ b/admission-webhook/glide.lock
@@ -1,11 +1,23 @@
 hash: 452cabc09329353086644a2ded2728e977d7c8630b6fb671f74b4d041a96b081
-updated: 2019-02-20T12:10:42.547606-08:00
+updated: 2019-03-02T10:29:43.625579-08:00
 imports:
+- name: github.com/beorn7/perks
+  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  subpackages:
+  - quantile
+- name: github.com/davecgh/go-spew
+  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
+  subpackages:
+  - spew
 - name: github.com/gogo/protobuf
   version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
   subpackages:
   - proto
   - sortkeys
+- name: github.com/golang/groupcache
+  version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
+  subpackages:
+  - lru
 - name: github.com/golang/protobuf
   version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
@@ -28,18 +40,51 @@ imports:
   version: 787624de3eb7bd915c329cba748687a3b22666a6
   subpackages:
   - diskcache
+- name: github.com/hashicorp/golang-lru
+  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+  subpackages:
+  - simplelru
+- name: github.com/imdario/mergo
+  version: 9316a62528ac99aaecb4e47eadd6dc8aa6533d58
 - name: github.com/json-iterator/go
   version: ab8a2e0c74be9d3be70b3184d9acc634935ded82
 - name: github.com/konsorten/go-windows-terminal-sequences
   version: 5c8c8bd35d3832f5d134ae1e1e375b69a4d25242
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
+- name: github.com/mitchellh/go-homedir
+  version: ae18d6b8b3205b561c79e8e5f69bff09736185f4
 - name: github.com/modern-go/concurrent
   version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
 - name: github.com/modern-go/reflect2
   version: 94122c33edd36123c84d5368cfb2b69df93a0ec8
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
+- name: github.com/prometheus/client_golang
+  version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- name: github.com/prometheus/client_model
+  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 13ba4ddd0caa9c28ca7b7bffe1dfa9ed8d5ef207
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: 65c1f6f8f0fc1e2185eb9863a3bc751496404259
+  subpackages:
+  - xfs
 - name: github.com/sirupsen/logrus
   version: bcd833dfe83d3cebad139e4a29ed79cb2318bf95
+- name: github.com/spf13/pflag
+  version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: golang.org/x/crypto
   version: de0752318171da717af4ce24d0a2e8626afaeb11
   subpackages:
@@ -97,6 +142,10 @@ imports:
   - jwt
 - name: gopkg.in/yaml.v2
   version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
+- name: gotest.tools
+  version: 045c470d778aacea42d88fdf7b4f9431c7bb8efb
+  subpackages:
+  - poll
 - name: k8s.io/api
   version: 74b699b93c15473932b89e3d1818ba8282f3b5ab
   subpackages:
@@ -135,6 +184,8 @@ imports:
   - storage/v1beta1
 - name: k8s.io/apiextensions-apiserver
   version: d4288ab6494571219e781fa423db363247635942
+  subpackages:
+  - pkg/features
 - name: k8s.io/apimachinery
   version: 572dfc7bdfcb4531361a17d27b92851f59acf0dc
   subpackages:
@@ -162,20 +213,26 @@ imports:
   - pkg/runtime/serializer/versioning
   - pkg/selection
   - pkg/types
+  - pkg/util/cache
   - pkg/util/clock
+  - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
   - pkg/util/intstr
   - pkg/util/json
+  - pkg/util/mergepatch
   - pkg/util/naming
   - pkg/util/net
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/strategicpatch
   - pkg/util/validation
   - pkg/util/validation/field
+  - pkg/util/wait
   - pkg/util/yaml
   - pkg/version
   - pkg/watch
+  - third_party/forked/golang/json
   - third_party/forked/golang/reflect
 - name: k8s.io/apiserver
   version: 26bc712632e1faf9efc6b63f712325c760ad1ebe
@@ -183,11 +240,59 @@ imports:
   - pkg/authentication/authenticator
   - pkg/authentication/serviceaccount
   - pkg/authentication/user
+  - pkg/features
+  - pkg/util/feature
 - name: k8s.io/client-go
   version: 6e4752048fde21176ab35eb54ec1117359830d8a
   subpackages:
   - discovery
   - dynamic
+  - informers
+  - informers/admissionregistration
+  - informers/admissionregistration/v1alpha1
+  - informers/admissionregistration/v1beta1
+  - informers/apps
+  - informers/apps/v1
+  - informers/apps/v1beta1
+  - informers/apps/v1beta2
+  - informers/auditregistration
+  - informers/auditregistration/v1alpha1
+  - informers/autoscaling
+  - informers/autoscaling/v1
+  - informers/autoscaling/v2beta1
+  - informers/autoscaling/v2beta2
+  - informers/batch
+  - informers/batch/v1
+  - informers/batch/v1beta1
+  - informers/batch/v2alpha1
+  - informers/certificates
+  - informers/certificates/v1beta1
+  - informers/coordination
+  - informers/coordination/v1beta1
+  - informers/core
+  - informers/core/v1
+  - informers/events
+  - informers/events/v1beta1
+  - informers/extensions
+  - informers/extensions/v1beta1
+  - informers/internalinterfaces
+  - informers/networking
+  - informers/networking/v1
+  - informers/policy
+  - informers/policy/v1beta1
+  - informers/rbac
+  - informers/rbac/v1
+  - informers/rbac/v1alpha1
+  - informers/rbac/v1beta1
+  - informers/scheduling
+  - informers/scheduling/v1alpha1
+  - informers/scheduling/v1beta1
+  - informers/settings
+  - informers/settings/v1alpha1
+  - informers/storage
+  - informers/storage/v1
+  - informers/storage/v1alpha1
+  - informers/storage/v1beta1
   - kubernetes
   - kubernetes/scheme
   - kubernetes/typed/admissionregistration/v1alpha1
@@ -222,6 +327,34 @@ imports:
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1alpha1
   - kubernetes/typed/storage/v1beta1
+  - listers/admissionregistration/v1alpha1
+  - listers/admissionregistration/v1beta1
+  - listers/apps/v1
+  - listers/apps/v1beta1
+  - listers/apps/v1beta2
+  - listers/auditregistration/v1alpha1
+  - listers/autoscaling/v1
+  - listers/autoscaling/v2beta1
+  - listers/autoscaling/v2beta2
+  - listers/batch/v1
+  - listers/batch/v1beta1
+  - listers/batch/v2alpha1
+  - listers/certificates/v1beta1
+  - listers/coordination/v1beta1
+  - listers/core/v1
+  - listers/events/v1beta1
+  - listers/extensions/v1beta1
+  - listers/networking/v1
+  - listers/policy/v1beta1
+  - listers/rbac/v1
+  - listers/rbac/v1alpha1
+  - listers/rbac/v1beta1
+  - listers/scheduling/v1alpha1
+  - listers/scheduling/v1beta1
+  - listers/settings/v1alpha1
+  - listers/storage/v1
+  - listers/storage/v1alpha1
+  - listers/storage/v1beta1
   - pkg/apis/clientauthentication
   - pkg/apis/clientauthentication/v1alpha1
   - pkg/apis/clientauthentication/v1beta1
@@ -229,28 +362,71 @@ imports:
   - plugin/pkg/client/auth/exec
   - rest
   - rest/watch
+  - tools/auth
+  - tools/cache
+  - tools/clientcmd
   - tools/clientcmd/api
+  - tools/clientcmd/api/latest
+  - tools/clientcmd/api/v1
   - tools/metrics
+  - tools/pager
+  - tools/record
   - tools/reference
   - transport
+  - util/buffer
   - util/cert
   - util/connrotation
   - util/flowcontrol
+  - util/homedir
   - util/integer
+  - util/retry
+- name: k8s.io/cloud-provider
+  version: 8f30ec879f0bed52ac8c95c19eb553509615e1a3
+- name: k8s.io/csi-api
+  version: a37926bd22154f4a8e21fda60bec9f3973c29fec
+  subpackages:
+  - pkg/apis/csi/v1alpha1
+  - pkg/client/clientset/versioned
+  - pkg/client/clientset/versioned/scheme
+  - pkg/client/clientset/versioned/typed/csi/v1alpha1
 - name: k8s.io/klog
   version: 8139d8cb77af419532b33dfa7dd09fbc5f1d344f
+- name: k8s.io/kube-openapi
+  version: c59034cc13d587f5ef4e85ca0ade0c1866ae8e1d
+  subpackages:
+  - pkg/util/proto
 - name: k8s.io/kubernetes
   version: 721bfa751924da8d1680787490c54b9179b1fed0
   subpackages:
+  - pkg/api/legacyscheme
   - pkg/apis/core
+  - pkg/apis/core/helper
+  - pkg/apis/core/v1/helper
+  - pkg/features
+  - pkg/kubelet/apis
   - pkg/serviceaccount
+  - pkg/util/file
+  - pkg/util/io
+  - pkg/util/mount
+  - pkg/util/nsenter
+  - pkg/util/resizefs
+  - pkg/util/strings
+  - pkg/volume
+  - pkg/volume/util
+  - pkg/volume/util/fs
+  - pkg/volume/util/recyclerclient
+  - pkg/volume/util/types
+  - pkg/volume/util/volumepathhandler
+- name: k8s.io/utils
+  version: 66066c83e385e385ccc3c964b44fd7dcd413d0ed
+  subpackages:
+  - clock
+  - exec
+  - exec/testing
+  - pointer
 - name: sigs.k8s.io/yaml
   version: fd68e9863619f6ec2fdd8625fe1f02e7c877e480
 testImports:
-- name: github.com/davecgh/go-spew
-  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
-  subpackages:
-  - spew
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:

--- a/admission-webhook/integration_tests/integration_test.go
+++ b/admission-webhook/integration_tests/integration_test.go
@@ -1,0 +1,331 @@
+package integrationtests
+
+import (
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// this is the JSON representation of the cred spec from templates/credspec-0.yml
+	expectedCredSpec0 = `{"ActiveDirectoryConfig":{"GroupManagedServiceAccounts":[{"Name":"WebApplication0","Scope":"CONTOSO"},{"Name":"WebApplication0","Scope":"contoso.com"}]},"CmsPlugins":["ActiveDirectory"],"DomainJoinConfig":{"DnsName":"contoso.com","DnsTreeName":"contoso.com","Guid":"244818ae-87ca-4fcd-92ec-e79e5252348a","MachineAccountName":"WebApplication0","NetBiosName":"CONTOSO","Sid":"S-1-5-21-2126729477-2524075714-3094792973"}}`
+	// this is the JSON representation of the cred spec from templates/credspec-1.yml
+	expectedCredSpec1 = `{"ActiveDirectoryConfig":{"GroupManagedServiceAccounts":[{"Name":"WebApplication1","Scope":"CONTOSO"},{"Name":"WebApplication1","Scope":"contoso.com"}]},"CmsPlugins":["ActiveDirectory"],"DomainJoinConfig":{"DnsName":"contoso.com","DnsTreeName":"contoso.com","Guid":"244818ae-87ca-4fcd-92ec-e79e5252348a","MachineAccountName":"WebApplication1","NetBiosName":"CONTOSO","Sid":"S-1-5-21-2126729477-2524175714-3194792973"}}`
+	// this is the JSON representation of the cred spec from templates/credspec-2.yml
+	expectedCredSpec2 = `{"ActiveDirectoryConfig":{"GroupManagedServiceAccounts":[{"Name":"WebApplication2","Scope":"CONTOSO"},{"Name":"WebApplication2","Scope":"contoso.com"}]},"CmsPlugins":["ActiveDirectory"],"DomainJoinConfig":{"DnsName":"contoso.com","DnsTreeName":"contoso.com","Guid":"244818ae-87ca-4fcd-92ec-e79e5252348a","MachineAccountName":"WebApplication2","NetBiosName":"CONTOSO","Sid":"S-1-5-21-2126729477-2524275714-3294792973"}}`
+
+	tmpRoot      = "tmp"
+	ymlExtension = ".yml"
+)
+
+func TestHappyPathWithPodLevelAnnotation(t *testing.T) {
+	testName := "happy-path-with-pod-level-annotation"
+	credSpecTemplates := []string{"credspec-0"}
+	templates := []string{"credspecs-users-rbac-role", "service-account", "sa-rbac-binding", "simple-with-gmsa"}
+
+	testConfig, tearDownFunc := integrationTestSetup(t, testName, credSpecTemplates, templates)
+	defer tearDownFunc()
+
+	pod := waitForPodToComeUp(t, testConfig.Namespace, "app="+testName)
+
+	assert.Equal(t, expectedCredSpec0, pod.Annotations["pod.alpha.windows.kubernetes.io/gmsa-credential-spec"])
+}
+
+func TestHappyPathWithContainerLevelAnnotation(t *testing.T) {
+	testName := "happy-path-with-container-level-annotation"
+	credSpecTemplates := []string{"credspec-0"}
+	templates := []string{"credspecs-users-rbac-role", "service-account", "sa-rbac-binding", "simple-with-container-level-gmsa"}
+
+	testConfig, tearDownFunc := integrationTestSetup(t, testName, credSpecTemplates, templates)
+	defer tearDownFunc()
+
+	pod := waitForPodToComeUp(t, testConfig.Namespace, "app="+testName)
+
+	assert.Equal(t, expectedCredSpec0, pod.Annotations["nginx.container.alpha.windows.kubernetes.io/gmsa-credential-spec"])
+}
+
+func TestHappyPathWithSeveralContainers(t *testing.T) {
+	testName := "happy-path-with-several-containers"
+	credSpecTemplates := []string{"credspec-0", "credspec-1", "credspec-2"}
+	templates := []string{"credspecs-users-rbac-role", "service-account", "sa-rbac-binding", "several-containers-with-gmsa"}
+
+	testConfig, tearDownFunc := integrationTestSetup(t, testName, credSpecTemplates, templates)
+	defer tearDownFunc()
+
+	pod := waitForPodToComeUp(t, testConfig.Namespace, "app="+testName)
+
+	assert.Equal(t, expectedCredSpec0, pod.Annotations["nginx0.container.alpha.windows.kubernetes.io/gmsa-credential-spec"])
+	assert.Equal(t, expectedCredSpec1, pod.Annotations["pod.alpha.windows.kubernetes.io/gmsa-credential-spec"])
+	assert.Equal(t, expectedCredSpec2, pod.Annotations["nginx2.container.alpha.windows.kubernetes.io/gmsa-credential-spec"])
+}
+
+func TestHappyPathWithPreSetMatchingAnnotations(t *testing.T) {
+	testName := "happy-path-with-pre-set-matching-annotations"
+	credSpecTemplates := []string{"credspec-0"}
+	templates := []string{"credspecs-users-rbac-role", "service-account", "sa-rbac-binding", "simple-with-gmsa"}
+
+	testConfig, tearDownFunc := integrationTestSetup(t, testName, credSpecTemplates, templates)
+	defer tearDownFunc()
+
+	pod := waitForPodToComeUp(t, testConfig.Namespace, "app="+testName)
+
+	assert.Equal(t, expectedCredSpec0, pod.Annotations["pod.alpha.windows.kubernetes.io/gmsa-credential-spec"])
+}
+
+func TestServiceAccountDoesNotHavePermissionsToUseCredSpec(t *testing.T) {
+	testName := "sa-does-not-have-permissions-to-use-cred-spec"
+	credSpecTemplates := []string{"credspec-0"}
+	templates := []string{"credspecs-users-rbac-role", "service-account", "simple-with-container-level-gmsa"}
+
+	testConfig, tearDownFunc := integrationTestSetup(t, testName, credSpecTemplates, templates)
+	defer tearDownFunc()
+
+	replicaSet := waitForReplicaSetGen1(t, testConfig.Namespace, "app="+testName)
+	assert.Equal(t, int32(0), replicaSet.Status.Replicas)
+	if assert.Equal(t, 1, len(replicaSet.Status.Conditions)) {
+		condition := replicaSet.Status.Conditions[0]
+
+		assert.Equal(t, condition.Reason, "FailedCreate")
+
+		expectedSubstr := fmt.Sprintf("service account %s is not authorized `use` gMSA cred spec %s", testConfig.ServiceAccountName, testConfig.CredSpecNames[0])
+		assert.Contains(t, condition.Message, expectedSubstr)
+	}
+}
+
+func TestCredSpecDoesNotExist(t *testing.T) {
+	testName := "cred-spec-does-not-exist"
+	templates := []string{"all-credspecs-users-rbac-role", "service-account", "sa-rbac-binding", "simple-with-unknown-gmsa"}
+
+	testConfig, tearDownFunc := integrationTestSetup(t, testName, nil, templates)
+	defer tearDownFunc()
+
+	replicaSet := waitForReplicaSetGen1(t, testConfig.Namespace, "app="+testName)
+	assert.Equal(t, int32(0), replicaSet.Status.Replicas)
+	if assert.Equal(t, 1, len(replicaSet.Status.Conditions)) {
+		condition := replicaSet.Status.Conditions[0]
+
+		assert.Equal(t, condition.Reason, "FailedCreate")
+
+		assert.Contains(t, condition.Message, "cred spec i-sure-dont-exist does not exist")
+	}
+}
+
+func TestCannotPreSetGMSAPodLevelContentsAnnotationsWithoutNameAnnotations(t *testing.T) {
+	testName := "cannot-pre-set-gmsa-pod-level-contents-annotations"
+	credSpecTemplates := []string{"credspec-0"}
+	templates := []string{"all-credspecs-users-rbac-role", "service-account", "sa-rbac-binding", "simple-with-preset-gmsa-pod-level-contents-annotation"}
+
+	testConfig, tearDownFunc := integrationTestSetup(t, testName, credSpecTemplates, templates)
+	defer tearDownFunc()
+
+	replicaSet := waitForReplicaSetGen1(t, testConfig.Namespace, "app="+testName)
+	assert.Equal(t, int32(0), replicaSet.Status.Replicas)
+	if assert.Equal(t, 1, len(replicaSet.Status.Conditions)) {
+		condition := replicaSet.Status.Conditions[0]
+
+		assert.Equal(t, condition.Reason, "FailedCreate")
+
+		assert.Contains(t, condition.Message, "cannot pre-set a pod's gMSA contents annotation (annotation \"pod.alpha.windows.kubernetes.io/gmsa-credential-spec\" present) without setting the corresponding name annotation")
+	}
+}
+
+func TestCannotPreSetGMSAContainerLevelContentsAnnotationsWithoutNameAnnotations(t *testing.T) {
+	testName := "cannot-pre-set-gmsa-container-level-contents-annotations"
+	credSpecTemplates := []string{"credspec-0"}
+	templates := []string{"all-credspecs-users-rbac-role", "service-account", "sa-rbac-binding", "simple-with-preset-gmsa-container-level-contents-annotation"}
+
+	testConfig, tearDownFunc := integrationTestSetup(t, testName, credSpecTemplates, templates)
+	defer tearDownFunc()
+
+	replicaSet := waitForReplicaSetGen1(t, testConfig.Namespace, "app="+testName)
+	assert.Equal(t, int32(0), replicaSet.Status.Replicas)
+	if assert.Equal(t, 1, len(replicaSet.Status.Conditions)) {
+		condition := replicaSet.Status.Conditions[0]
+
+		assert.Equal(t, condition.Reason, "FailedCreate")
+
+		assert.Contains(t, condition.Message, "cannot pre-set a pod's gMSA contents annotation (annotation \"nginx.container.alpha.windows.kubernetes.io/gmsa-credential-spec\" present) without setting the corresponding name annotation")
+	}
+}
+
+func TestCannotUpdateExistingPodLevelGMSAAnnotations(t *testing.T) {
+	testName := "cannot-update-gmsa-pod-level-annotations"
+	credSpecTemplates := []string{"credspec-0"}
+	singlePodTemplate := "single-pod-with-gmsa"
+	templates := []string{"credspecs-users-rbac-role", "service-account", "sa-rbac-binding", singlePodTemplate}
+
+	testConfig, tearDownFunc := integrationTestSetup(t, testName, credSpecTemplates, templates)
+	defer tearDownFunc()
+
+	// let's check that the pod has come up correctly, and has the correct GMSA cred inlined
+	pod, err := kubeClient(t).CoreV1().Pods(testConfig.Namespace).Get(testName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, expectedCredSpec0, pod.Annotations["pod.alpha.windows.kubernetes.io/gmsa-credential-spec"])
+
+	// now let's try to update the content annotation
+	testConfig.ExtraAnnotations = map[string]template.HTML{
+		"pod.alpha.windows.kubernetes.io/gmsa-credential-spec": template.HTML("'" + expectedCredSpec1 + "'"),
+	}
+	renderedTemplate := renderTemplate(t, testConfig, singlePodTemplate)
+	success, _, stderr := applyManifest(t, renderedTemplate)
+	if assert.False(t, success) {
+		assert.Contains(t, stderr, "cannot update an existing pod's gMSA annotation (annotation pod.alpha.windows.kubernetes.io/gmsa-credential-spec changed)")
+	}
+	testConfig.ExtraAnnotations = nil
+
+	// and same for the name annotation
+	testConfig.CredSpecNames[0] = "new-credspec"
+	renderedTemplate = renderTemplate(t, testConfig, singlePodTemplate)
+	success, _, stderr = applyManifest(t, renderedTemplate)
+	if assert.False(t, success) {
+		assert.Contains(t, stderr, "cannot update an existing pod's gMSA annotation (annotation pod.alpha.windows.kubernetes.io/gmsa-credential-spec-name changed)")
+	}
+}
+
+func TestCannotUpdateExistingContainerLevelGMSAAnnotations(t *testing.T) {
+	testName := "cannot-update-gmsa-container-level-annotations"
+	credSpecTemplates := []string{"credspec-0"}
+	singlePodTemplate := "single-pod-with-container-level-gmsa"
+	templates := []string{"credspecs-users-rbac-role", "service-account", "sa-rbac-binding", singlePodTemplate}
+
+	testConfig, tearDownFunc := integrationTestSetup(t, testName, credSpecTemplates, templates)
+	defer tearDownFunc()
+
+	// let's check that the pod has come up correctly, and has the correct GMSA cred inlined
+	pod, err := kubeClient(t).CoreV1().Pods(testConfig.Namespace).Get(testName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, expectedCredSpec0, pod.Annotations[testName+".container.alpha.windows.kubernetes.io/gmsa-credential-spec"])
+
+	// now let's try to update the content annotation
+	testConfig.ExtraAnnotations = map[string]template.HTML{
+		testName + ".container.alpha.windows.kubernetes.io/gmsa-credential-spec": template.HTML("'" + expectedCredSpec1 + "'"),
+	}
+	renderedTemplate := renderTemplate(t, testConfig, singlePodTemplate)
+	success, _, stderr := applyManifest(t, renderedTemplate)
+	if assert.False(t, success) {
+		expectedSubstr := fmt.Sprintf("cannot update an existing pod's gMSA annotation (annotation %s.container.alpha.windows.kubernetes.io/gmsa-credential-spec changed)", testName)
+		assert.Contains(t, stderr, expectedSubstr)
+	}
+	testConfig.ExtraAnnotations = nil
+
+	// and same for the name annotation
+	testConfig.CredSpecNames[0] = "new-credspec"
+	renderedTemplate = renderTemplate(t, testConfig, singlePodTemplate)
+	success, _, stderr = applyManifest(t, renderedTemplate)
+	if assert.False(t, success) {
+		expectedSubstr := fmt.Sprintf("cannot update an existing pod's gMSA annotation (annotation %s.container.alpha.windows.kubernetes.io/gmsa-credential-spec-name changed)", testName)
+		assert.Contains(t, stderr, expectedSubstr)
+	}
+}
+
+/* Helpers */
+
+type testConfig struct {
+	TestName           string
+	Namespace          string
+	TmpDir             string
+	CredSpecNames      []string
+	ClusterRoleName    string
+	ServiceAccountName string
+	RoleBindingName    string
+	ExtraAnnotations   map[string]template.HTML
+}
+
+// integrationTestSetup creates a new namespace to play in, and returns a function to
+// tear it down afterwards.
+// It also applies the given templates
+func integrationTestSetup(t *testing.T, name string, credSpecTemplates, templates []string) (*testConfig, func()) {
+	if _, err := os.Stat(tmpRoot); os.IsNotExist(err) {
+		if err = os.Mkdir(tmpRoot, os.ModePerm); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tmpDir, err := ioutil.TempDir(tmpRoot, name+"-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespace := createNamespace(t, "")
+
+	credSpecNames := make([]string, len(credSpecTemplates))
+	for i := range credSpecTemplates {
+		credSpecNames[i] = name + "-cred-spec-" + strconv.Itoa(i)
+	}
+
+	testConfig := &testConfig{
+		TestName:  name,
+		Namespace: namespace,
+		TmpDir:    tmpDir,
+
+		CredSpecNames:      credSpecNames,
+		ClusterRoleName:    name + "-credspecs-users",
+		ServiceAccountName: name + "-service-account",
+		RoleBindingName:    name + "-use-credspecs",
+	}
+
+	templatePaths := make([]string, len(credSpecTemplates)+len(templates))
+	for i, template := range append(credSpecTemplates, templates...) {
+		templatePaths[i] = renderTemplate(t, testConfig, template)
+		applyManifestOrFail(t, templatePaths[i])
+	}
+
+	tearDownFunc := func() {
+		// helps speed us test when working locally against a throw-away cluster
+		// deleting namespaces seems to be a rather heavy operation
+		if _, present := os.LookupEnv("K8S_GMSA_ADMISSION_WEBHOOK_INTEGRATION_TEST_SKIP_CLEANUP"); present {
+			return
+		}
+
+		for _, templatePath := range templatePaths {
+			deleteManifest(t, templatePath)
+		}
+
+		deleteNamespace(t, namespace)
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return testConfig, tearDownFunc
+}
+
+// renderTemplate renders a template, and returns its path.
+func renderTemplate(t *testing.T, testConfig *testConfig, name string) string {
+	if name[len(name)-len(ymlExtension):] != ymlExtension {
+		name += ymlExtension
+	}
+
+	contents, err := ioutil.ReadFile(path.Join("templates", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tplName := fmt.Sprintf("%s-%s", testConfig.Namespace, name)
+	tpl, err := template.New(tplName).Parse(string(contents))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	renderedTemplate, err := os.Create(path.Join(testConfig.TmpDir, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer renderedTemplate.Close()
+
+	if err = tpl.Execute(renderedTemplate, *testConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	return renderedTemplate.Name()
+}

--- a/admission-webhook/integration_tests/kube.go
+++ b/admission-webhook/integration_tests/kube.go
@@ -1,0 +1,173 @@
+package integrationtests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	"gotest.tools/poll"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/pkg/volume/util"
+)
+
+func kubeClient(t *testing.T) kubernetes.Interface {
+	kubeConfigPath, err := homedir.Expand("~/.kube/config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return client
+}
+
+// waitForPodToComeUp waits for a pod matching `selector` to come up in `namespace`, and returns it.
+func waitForPodToComeUp(t *testing.T, namespace, selector string, pollOps ...poll.SettingOp) *corev1.Pod {
+	fetcher := func(client kubernetes.Interface, listOptions metav1.ListOptions) ([]interface{}, error) {
+		podList, err := client.CoreV1().Pods(namespace).List(listOptions)
+		if err == nil {
+			result := make([]interface{}, len(podList.Items))
+			for i, item := range podList.Items {
+				result[i] = item
+			}
+			return result, nil
+		}
+		return nil, err
+	}
+
+	rawPod := waitForKubeObject(t, fetcher, namespace, selector, "pod", pollOps...)
+	pod := rawPod.(corev1.Pod)
+	return &pod
+}
+
+// waitForReplicaSet waits for a replica set matching `selector` to come up in `namespace`, and returns it.
+func waitForReplicaSet(t *testing.T, namespace, selector string, pollOps ...poll.SettingOp) *appsv1.ReplicaSet {
+	fetcher := func(client kubernetes.Interface, listOptions metav1.ListOptions) ([]interface{}, error) {
+		rsList, err := client.AppsV1().ReplicaSets(namespace).List(listOptions)
+		if err == nil {
+			result := make([]interface{}, len(rsList.Items))
+			for i, item := range rsList.Items {
+				result[i] = item
+			}
+			return result, nil
+		}
+		return nil, err
+	}
+
+	rawReplicaSet := waitForKubeObject(t, fetcher, namespace, selector, "replica set", pollOps...)
+	replicaSet := rawReplicaSet.(appsv1.ReplicaSet)
+	return &replicaSet
+}
+
+// waitForReplicaSetGen1 waits for a given replica set to have its `Status.ObservedGeneration` field grow to > 0
+// Comes in handy to wait for k8s to reach a decision for a given replicaset
+func waitForReplicaSetGen1(t *testing.T, namespace, selector string, pollOps ...poll.SettingOp) *appsv1.ReplicaSet {
+	replicaSet := waitForReplicaSet(t, namespace, selector, pollOps...)
+	var err error
+
+	client := kubeClient(t)
+
+	pollingFunc := func(_ poll.LogT) poll.Result {
+		replicaSet, err = client.AppsV1().ReplicaSets(namespace).Get(replicaSet.Name, metav1.GetOptions{})
+		if err != nil {
+			return poll.Error(err)
+		}
+
+		if replicaSet.Status.ObservedGeneration == 0 {
+			return poll.Continue("replicaset %s is still at generation 0", replicaSet.Name)
+		}
+		return poll.Success()
+	}
+
+	poll.WaitOn(t, pollingFunc, pollOps...)
+
+	return replicaSet
+}
+
+// waitForKubeObject waits for fetcher to return a list of one object matching `selector` in `namespace`, and returns it.
+func waitForKubeObject(t *testing.T, fetcher func(kubernetes.Interface, metav1.ListOptions) ([]interface{}, error), namespace, selector, displayableName string, pollOps ...poll.SettingOp) (object interface{}) {
+	client := kubeClient(t)
+	listOptions := metav1.ListOptions{LabelSelector: selector}
+
+	pollingFunc := func(_ poll.LogT) poll.Result {
+		list, err := fetcher(client, listOptions)
+
+		if err != nil {
+			return poll.Error(err)
+		}
+
+		switch len(list) {
+		case 0:
+			return poll.Continue("no %s matching %s in namespace %s", displayableName, selector, namespace)
+		case 1:
+			object = list[0]
+			return poll.Success()
+		default:
+			err = fmt.Errorf("expected no more than 1 %s matching %s in namespace %s, got %v", displayableName, selector, namespace, len(list))
+			return poll.Error(err)
+		}
+	}
+
+	poll.WaitOn(t, pollingFunc, pollOps...)
+
+	return
+}
+
+const testNamespacePrefix = "gmsa-webhook-test-"
+
+// createNamespace creates a new namespace, and fails the test if it already exists.
+// if passed an empty string, it picks a random name and returns it.
+func createNamespace(t *testing.T, name string) string {
+	if name == "" {
+		name = testNamespacePrefix + randomHexString(t, util.ResourceNameLengthLimit-len(testNamespacePrefix))
+	}
+
+	runKubectlCommandOrFail(t, "create", "namespace", name)
+
+	return name
+}
+
+func deleteNamespace(t *testing.T, name string) {
+	runKubectlCommandOrFail(t, "delete", "namespace", name)
+}
+
+func applyManifestOrFail(t *testing.T, path string) {
+	runKubectlCommandOrFail(t, "apply", "-f", path)
+}
+
+func applyManifest(t *testing.T, path string) (success bool, stdout string, stderr string) {
+	return runKubectlCommand(t, "apply", "-f", path)
+}
+
+func deleteManifest(t *testing.T, path string) {
+	runKubectlCommandOrFail(t, "delete", "-f", path)
+}
+
+func runKubectlCommandOrFail(t *testing.T, args ...string) {
+	runCommandOrFail(t, kubectl(), args...)
+}
+
+func runKubectlCommand(t *testing.T, args ...string) (success bool, stdout string, stderr string) {
+	return runCommand(t, kubectl(), args...)
+}
+
+func kubectl() (kubectl string) {
+	if fromEnv, present := os.LookupEnv("KUBECTL"); present && fromEnv != "" {
+		kubectl = fromEnv
+	} else {
+		kubectl = "kubectl"
+	}
+	return
+}

--- a/admission-webhook/integration_tests/templates/all-credspecs-users-rbac-role.yml
+++ b/admission-webhook/integration_tests/templates/all-credspecs-users-rbac-role.yml
@@ -1,0 +1,10 @@
+# an RBAC role to grant `use` access to all credspecs
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .ClusterRoleName }}
+rules:
+- apiGroups: ["windows.k8s.io"]
+  resources: ["gmsacredentialspecs"]
+  verbs: ["use"]

--- a/admission-webhook/integration_tests/templates/credspec-0.yml
+++ b/admission-webhook/integration_tests/templates/credspec-0.yml
@@ -1,0 +1,22 @@
+# a sample cred spec
+
+apiVersion: windows.k8s.io/v1alpha1
+kind: GMSACredentialSpec
+metadata:
+  name: {{ index .CredSpecNames 0 }}
+credspec:
+  ActiveDirectoryConfig:
+    GroupManagedServiceAccounts:
+    - Name: WebApplication0
+      Scope: CONTOSO
+    - Name: WebApplication0
+      Scope: contoso.com
+  CmsPlugins:
+  - ActiveDirectory
+  DomainJoinConfig:
+    DnsName: contoso.com
+    DnsTreeName: contoso.com
+    Guid: 244818ae-87ca-4fcd-92ec-e79e5252348a
+    MachineAccountName: WebApplication0
+    NetBiosName: CONTOSO
+    Sid: S-1-5-21-2126729477-2524075714-3094792973

--- a/admission-webhook/integration_tests/templates/credspec-1.yml
+++ b/admission-webhook/integration_tests/templates/credspec-1.yml
@@ -1,0 +1,22 @@
+# a sample cred spec
+
+apiVersion: windows.k8s.io/v1alpha1
+kind: GMSACredentialSpec
+metadata:
+  name: {{ index .CredSpecNames 1 }}
+credspec:
+  ActiveDirectoryConfig:
+    GroupManagedServiceAccounts:
+    - Name: WebApplication1
+      Scope: CONTOSO
+    - Name: WebApplication1
+      Scope: contoso.com
+  CmsPlugins:
+  - ActiveDirectory
+  DomainJoinConfig:
+    DnsName: contoso.com
+    DnsTreeName: contoso.com
+    Guid: 244818ae-87ca-4fcd-92ec-e79e5252348a
+    MachineAccountName: WebApplication1
+    NetBiosName: CONTOSO
+    Sid: S-1-5-21-2126729477-2524175714-3194792973

--- a/admission-webhook/integration_tests/templates/credspec-2.yml
+++ b/admission-webhook/integration_tests/templates/credspec-2.yml
@@ -1,0 +1,22 @@
+# a sample cred spec
+
+apiVersion: windows.k8s.io/v1alpha1
+kind: GMSACredentialSpec
+metadata:
+  name: {{ index .CredSpecNames 2 }}
+credspec:
+  ActiveDirectoryConfig:
+    GroupManagedServiceAccounts:
+    - Name: WebApplication2
+      Scope: CONTOSO
+    - Name: WebApplication2
+      Scope: contoso.com
+  CmsPlugins:
+  - ActiveDirectory
+  DomainJoinConfig:
+    DnsName: contoso.com
+    DnsTreeName: contoso.com
+    Guid: 244818ae-87ca-4fcd-92ec-e79e5252348a
+    MachineAccountName: WebApplication2
+    NetBiosName: CONTOSO
+    Sid: S-1-5-21-2126729477-2524275714-3294792973

--- a/admission-webhook/integration_tests/templates/credspecs-users-rbac-role.yml
+++ b/admission-webhook/integration_tests/templates/credspecs-users-rbac-role.yml
@@ -1,0 +1,14 @@
+# an RBAC role to grant `use` access to some credspecs
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .ClusterRoleName }}
+rules:
+- apiGroups: ["windows.k8s.io"]
+  resources: ["gmsacredentialspecs"]
+  verbs: ["use"]
+  resourceNames:
+{{- range $_, $csn := .CredSpecNames }}
+    - {{ $csn }}
+{{- end }}

--- a/admission-webhook/integration_tests/templates/happy-path-with-pre-set-matching-annotations.yml
+++ b/admission-webhook/integration_tests/templates/happy-path-with-pre-set-matching-annotations.yml
@@ -1,0 +1,28 @@
+## a simple deployment with a pod-level GMSA annotation
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .TestName }}
+  name: {{ .TestName }}
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .TestName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .TestName }}
+      annotations:
+        pod.alpha.windows.kubernetes.io/gmsa-credential-spec-name: {{ index .CredSpecNames 0 }}
+        pod.alpha.windows.kubernetes.io/gmsa-credential-spec: '{"Sid":"S-1-5-21-2126729477-2524075714-3094792973", "ActiveDirectoryConfig":{"GroupManagedServiceAccounts":[{"Name":"WebApplication0","Scope":"CONTOSO"},{"Name":"WebApplication0","Scope":"contoso.com"}]},"CmsPlugins":["ActiveDirectory"],"DomainJoinConfig":{"DnsName":"contoso.com","DnsTreeName":"contoso.com","Guid":"244818ae-87ca-4fcd-92ec-e79e5252348a","MachineAccountName":"WebApplication0","NetBiosName":"CONTOSO"}}'
+    spec:
+      serviceAccountName: {{ .ServiceAccountName }}
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80

--- a/admission-webhook/integration_tests/templates/sa-rbac-binding.yml
+++ b/admission-webhook/integration_tests/templates/sa-rbac-binding.yml
@@ -1,0 +1,15 @@
+## an RBAC role binding for a service account
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .RoleBindingName }}
+  namespace: {{ .Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .ServiceAccountName }}
+  namespace: {{ .Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .ClusterRoleName }}
+  apiGroup: rbac.authorization.k8s.io

--- a/admission-webhook/integration_tests/templates/service-account.yml
+++ b/admission-webhook/integration_tests/templates/service-account.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .ServiceAccountName }}
+  namespace: {{ .Namespace }}

--- a/admission-webhook/integration_tests/templates/several-containers-with-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/several-containers-with-gmsa.yml
@@ -1,0 +1,37 @@
+## a simple deployment with several containers: 2 with their own GMSA, and 1 without it, plus a pod-level annotation
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .TestName }}
+  name: {{ .TestName }}
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .TestName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .TestName }}
+      annotations:
+        nginx0.container.alpha.windows.kubernetes.io/gmsa-credential-spec-name: {{ index .CredSpecNames 0 }}
+        pod.alpha.windows.kubernetes.io/gmsa-credential-spec-name: {{ index .CredSpecNames 1 }}
+        nginx2.container.alpha.windows.kubernetes.io/gmsa-credential-spec-name: {{ index .CredSpecNames 2 }}
+    spec:
+      serviceAccountName: {{ .ServiceAccountName }}
+      containers:
+      - image: nginx
+        name: nginx0
+        ports:
+        - containerPort: 80
+      - image: nginx
+        name: nginx1
+        ports:
+        - containerPort: 80
+      - image: nginx
+        name: nginx2
+        ports:
+        - containerPort: 80

--- a/admission-webhook/integration_tests/templates/simple-with-container-level-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-container-level-gmsa.yml
@@ -1,0 +1,27 @@
+## a simple deployment with a container-level GMSA annotation
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .TestName }}
+  name: {{ .TestName }}
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .TestName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .TestName }}
+      annotations:
+        nginx.container.alpha.windows.kubernetes.io/gmsa-credential-spec-name: {{ index .CredSpecNames 0 }}
+    spec:
+      serviceAccountName: {{ .ServiceAccountName }}
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80

--- a/admission-webhook/integration_tests/templates/simple-with-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-gmsa.yml
@@ -1,0 +1,27 @@
+## a simple deployment with a pod-level GMSA annotation
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .TestName }}
+  name: {{ .TestName }}
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .TestName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .TestName }}
+      annotations:
+        pod.alpha.windows.kubernetes.io/gmsa-credential-spec-name: {{ index .CredSpecNames 0 }}
+    spec:
+      serviceAccountName: {{ .ServiceAccountName }}
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80

--- a/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-container-level-contents-annotation.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-container-level-contents-annotation.yml
@@ -1,0 +1,27 @@
+## a simple deployment with a container-level GMSA *content* annotation already set
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .TestName }}
+  name: {{ .TestName }}
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .TestName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .TestName }}
+      annotations:
+        nginx.container.alpha.windows.kubernetes.io/gmsa-credential-spec: '{"ActiveDirectoryConfig":{"GroupManagedServiceAccounts":[{"Name":"WebApplication0","Scope":"CONTOSO"},{"Name":"WebApplication0","Scope":"contoso.com"}]},"CmsPlugins":["ActiveDirectory"],"DomainJoinConfig":{"DnsName":"contoso.com","DnsTreeName":"contoso.com","Guid":"244818ae-87ca-4fcd-92ec-e79e5252348a","MachineAccountName":"WebApplication0","NetBiosName":"CONTOSO","Sid":"S-1-5-21-2126729477-2524075714-3094792973"}}'
+    spec:
+      serviceAccountName: {{ .ServiceAccountName }}
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80

--- a/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-pod-level-contents-annotation.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-pod-level-contents-annotation.yml
@@ -1,0 +1,27 @@
+## a simple deployment with a pod-level GMSA *content* annotation already set
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .TestName }}
+  name: {{ .TestName }}
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .TestName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .TestName }}
+      annotations:
+        pod.alpha.windows.kubernetes.io/gmsa-credential-spec: '{"ActiveDirectoryConfig":{"GroupManagedServiceAccounts":[{"Name":"WebApplication0","Scope":"CONTOSO"},{"Name":"WebApplication0","Scope":"contoso.com"}]},"CmsPlugins":["ActiveDirectory"],"DomainJoinConfig":{"DnsName":"contoso.com","DnsTreeName":"contoso.com","Guid":"244818ae-87ca-4fcd-92ec-e79e5252348a","MachineAccountName":"WebApplication0","NetBiosName":"CONTOSO","Sid":"S-1-5-21-2126729477-2524075714-3094792973"}}'
+    spec:
+      serviceAccountName: {{ .ServiceAccountName }}
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80

--- a/admission-webhook/integration_tests/templates/simple-with-unknown-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-unknown-gmsa.yml
@@ -1,0 +1,27 @@
+## a simple deployment with a pod-level GMSA annotation referring a cred spec that doesn't exist
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .TestName }}
+  name: {{ .TestName }}
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .TestName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .TestName }}
+      annotations:
+        pod.alpha.windows.kubernetes.io/gmsa-credential-spec-name: i-sure-dont-exist
+    spec:
+      serviceAccountName: {{ .ServiceAccountName }}
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80

--- a/admission-webhook/integration_tests/templates/single-pod-with-container-level-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/single-pod-with-container-level-gmsa.yml
@@ -1,0 +1,21 @@
+## this deploys a single pod with a container-level GMSA cred spec
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: {{ .TestName }}
+  name: {{ .TestName }}
+  namespace: {{ .Namespace }}
+  annotations:
+    {{ .TestName }}.container.alpha.windows.kubernetes.io/gmsa-credential-spec-name: {{ index .CredSpecNames 0 }}
+{{- range $k, $v := .ExtraAnnotations }}
+    {{ $k }}: {{ $v }}
+{{- end }}
+spec:
+  serviceAccountName: {{ .ServiceAccountName }}
+  containers:
+  - name: {{ .TestName }}
+    image: nginx
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never

--- a/admission-webhook/integration_tests/templates/single-pod-with-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/single-pod-with-gmsa.yml
@@ -1,0 +1,21 @@
+## this deploys a single pod with a pod-level GMSA cred spec
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: {{ .TestName }}
+  name: {{ .TestName }}
+  namespace: {{ .Namespace }}
+  annotations:
+    pod.alpha.windows.kubernetes.io/gmsa-credential-spec-name: {{ index .CredSpecNames 0 }}
+{{- range $k, $v := .ExtraAnnotations }}
+    {{ $k }}: {{ $v }}
+{{- end }}
+spec:
+  serviceAccountName: {{ .ServiceAccountName }}
+  containers:
+  - name: nginx
+    image: {{ .TestName }}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never

--- a/admission-webhook/integration_tests/utils.go
+++ b/admission-webhook/integration_tests/utils.go
@@ -1,0 +1,68 @@
+package integrationtests
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"testing"
+)
+
+func runCommandOrFail(t *testing.T, name string, args ...string) {
+	success, stdout, stderr := runCommand(t, name, args...)
+	if !success {
+		t.Fatal(stdout, stderr)
+	}
+	fmt.Print(stdout)
+}
+
+func runCommand(t *testing.T, name string, args ...string) (success bool, stdout string, stderr string) {
+	cmd := exec.Command(name, args...)
+	stdoutReader, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderrReader, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	success = true
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	stdoutBytes, err := ioutil.ReadAll(stdoutReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderrBytes, err := ioutil.ReadAll(stderrReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			success = false
+		} else {
+			t.Fatal(err)
+		}
+	}
+
+	return success, string(stdoutBytes), string(stderrBytes)
+}
+
+func randomHexString(t *testing.T, length int) string {
+	b := length / 2
+	randBytes := make([]byte, b)
+
+	if n, err := rand.Reader.Read(randBytes); err != nil || n != b {
+		if err == nil {
+			err = fmt.Errorf("only got %v random bytes, expected %v", n, b)
+		}
+		t.Fatal(err)
+	}
+
+	return hex.EncodeToString(randBytes)
+}

--- a/admission-webhook/make/deps.mk
+++ b/admission-webhook/make/deps.mk
@@ -14,13 +14,12 @@ deps_update: $(GLIDE_BIN)
 
 GLIDE_URL = https://glide.sh/get
 $(GLIDE_BIN):
-	@ if [ ! "$$GOPATH" ]; then \
-		echo "GOPATH env var not defined, cannot install glide"; \
-		exit 1; \
-	fi
-	mkdir -p $(dir $(GLIDE_BIN))
-	if which curl &> /dev/null; then \
-		curl $(GLIDE_URL) | sh; \
-	else \
-		wget -O - $(GLIDE_URL) 2> /dev/null | sh; \
-	fi
+ifeq ($(GOPATH),)
+	@ echo "GOPATH env var not defined, cannot install glide"
+	exit 1
+endif
+ifeq ($(WGET),)
+	$(CURL) $(GLIDE_URL) | sh
+else
+	$(WGET) -O - $(GLIDE_URL) 2> /dev/null | sh
+endif

--- a/admission-webhook/make/dev_cluster.mk
+++ b/admission-webhook/make/dev_cluster.mk
@@ -1,0 +1,132 @@
+# K8S version can be overrident
+KUBERNETES_VERSION ?= 1.13
+# see https://github.com/kubernetes-sigs/kubeadm-dind-cluster/releases
+KUBEADM_DIND_VERSION = v0.1.0
+
+ifeq ($(filter $(KUBERNETES_VERSION),1.11 1.12 1.13),)
+$(error "Kubernetes version $(KUBERNETES_VERSION) not supported")
+endif
+
+DEPLOYMENT_NAME ?= windows-gmsa-dev
+NAMESPACE ?= windows-gmsa-dev
+
+# kubeadm DinD settings
+KUBEADM_DIND_CLUSTER_SCRIPT = dev/kubeadm_dind_scripts/$(KUBEADM_DIND_VERSION)/dind-cluster-v$(KUBERNETES_VERSION).sh
+KUBEADM_DIND_CLUSTER_SCRIPT_URL = https://github.com/kubernetes-sigs/kubeadm-dind-cluster/releases/download/$(KUBEADM_DIND_VERSION)/dind-cluster-v$(KUBERNETES_VERSION).sh
+KUBEADM_DIND_DIR = ~/.kubeadm-dind-cluster
+ADMISSION_PLUGINS = NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+
+KUBECTL = $(KUBEADM_DIND_DIR)/kubectl
+CERTS_DIR = dev/certs_dir
+MANIFESTS_FILE = dev/gmsa-webhook.yml
+
+# starts a new DinD cluster (see https://github.com/kubernetes-sigs/kubeadm-dind-cluster)
+.PHONY: cluster_start
+cluster_start: $(KUBEADM_DIND_CLUSTER_SCRIPT)
+	NUM_NODES=1 APISERVER_enable_admission_plugins=$(ADMISSION_PLUGINS) $(KUBEADM_DIND_CLUSTER_SCRIPT) up
+	@ echo "### Kubectl version: ###"
+	$(KUBECTL) version
+
+# stops the DinD cluster
+.PHONY: cluster_stop
+cluster_stop: $(KUBEADM_DIND_CLUSTER_SCRIPT)
+	$(KUBEADM_DIND_CLUSTER_SCRIPT) down
+
+# removes the DinD cluster
+.PHONY: clean_cluster
+clean_cluster: clean_certs cluster_stop
+	$(KUBEADM_DIND_CLUSTER_SCRIPT) clean
+	rm -rf $(KUBEADM_DIND_DIR)
+
+.PHONY: clean_certs
+clean_certs:
+	rm -rf $(CERTS_DIR)
+
+# deploys the webhook to the DinD cluster with the dev image
+.PHONY: deploy_dev_webhook
+deploy_dev_webhook:
+	K8S_GMSA_IMAGE=$(DEV_IMAGE_NAME) $(MAKE) _deploy_webhook
+
+# deploys the webhook to the DinD cluster with the release image
+.PHONY: deploy_webhook
+deploy_webhook:
+	K8S_GMSA_IMAGE=$(IMAGE_NAME) $(MAKE) _deploy_webhook
+
+# removes the webhook from the DinD cluster
+.PHONY: remove_webhook
+remove_webhook:
+ifeq ($(wildcard $(MANIFESTS_FILE)),)
+	@ echo "No manifests file found at $(MANIFESTS_FILE), nothing to remove"
+else
+	$(KUBECTL) delete -f $(MANIFESTS_FILE) || true
+endif
+
+### "Private" targets below ###
+
+# starts the DinD cluster only if it's not already running
+.PHONY: _start_cluster_if_not_running
+_start_cluster_if_not_running: $(KUBEADM_DIND_CLUSTER_SCRIPT)
+	@ if [ -x $(KUBECTL) ] && timeout 2 $(KUBECTL) version &> /dev/null; then \
+		echo "Dev cluster already running"; \
+	else \
+		$(MAKE) cluster_start; \
+	fi
+
+# deploys the webhook to the DinD cluster
+# if $K8S_GMSA_DEPLOY_METHOD is set to "download", then it will deploy by downloading
+# the deploy script as documented in the README, using $K8S_GMSA_DEPLOY_DOWNLOAD_REPO and
+# $K8S_GMSA_DEPLOY_DOWNLOAD_REV env variables to build the download URL. If those two are not
+# set, it will try to infer them from the current's branch remote branch and the current
+# HEAD's SHA.
+.PHONY: _deploy_webhook
+_deploy_webhook: _copy_image_if_needed remove_webhook
+ifeq ($(K8S_GMSA_IMAGE),)
+	@ echo "Cannot call target $@ without setting K8S_GMSA_IMAGE"
+	exit 1
+endif
+	mkdir -p $(dir $(MANIFESTS_FILE))
+ifeq ($(K8S_GMSA_DEPLOY_METHOD),download)
+	@ if [ ! "$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO" ]; then \
+        SHORT_UPSTREAM="$$(git for-each-ref --format='%(upstream:short)' "$$(git symbolic-ref -q HEAD)" 2>/dev/null)"; \
+        if [[ $$? == 0 ]]; then \
+          REMOTE_NAME=$${SHORT_UPSTREAM%%/*} ; \
+            REMOTE_URL="$$(git remote get-url "$$REMOTE_NAME" 2>/dev/null)"; \
+            if [[ $$? == 0 ]]; then \
+              REPO_OWNER_AND_NAME=$${REMOTE_URL#*:} && K8S_GMSA_DEPLOY_DOWNLOAD_REPO=$${REPO_OWNER_AND_NAME%.*}; \
+            fi; \
+        fi; \
+        [ "$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO" ] || K8S_GMSA_DEPLOY_DOWNLOAD_REPO='kubernetes-sigs/windows-gmsa'; \
+      fi \
+      && if [ ! "$$K8S_GMSA_DEPLOY_DOWNLOAD_REV" ]; then K8S_GMSA_DEPLOY_DOWNLOAD_REV="$$(git rev-parse HEAD)"; fi \
+      && CMD="curl -sL 'https://raw.githubusercontent.com/$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO/$$K8S_GMSA_DEPLOY_DOWNLOAD_REV/admission-webhook/deploy/deploy-gmsa-webhook.sh' | K8S_GMSA_DEPLOY_DOWNLOAD_REPO='$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO' K8S_GMSA_DEPLOY_DOWNLOAD_REV='$$K8S_GMSA_DEPLOY_DOWNLOAD_REV' KUBECTL=$(KUBECTL) bash -s -- --file '$(MANIFESTS_FILE)' --name '$(DEPLOYMENT_NAME)' --namespace '$(NAMESPACE)' --image '$(K8S_GMSA_IMAGE)' --certs-dir '$(CERTS_DIR)'" \
+      && echo "$$CMD" && eval "$$CMD"
+else
+	KUBECTL=$(KUBECTL) ./deploy/deploy-gmsa-webhook.sh --file "$(MANIFESTS_FILE)" --name "$(DEPLOYMENT_NAME)" --namespace "$(NAMESPACE)" --image "$(K8S_GMSA_IMAGE)" --certs-dir "$(CERTS_DIR)"
+endif
+
+# copies the image to the DinD cluster only if it's not already up-to-date
+.PHONY: _copy_image_if_needed
+_copy_image_if_needed: _start_cluster_if_not_running
+ifeq ($(K8S_GMSA_IMAGE),)
+	@ echo "Cannot call target $@ without setting K8S_GMSA_IMAGE"
+	exit 1
+endif
+	@ LOCAL_IMG_ID=$$(docker image inspect "$$K8S_GMSA_IMAGE" -f '{{ .Id }}'); \
+	  STATUS=$$? ; if [[ $$STATUS != 0 ]]; then echo "Unable to retrieve image ID for $$K8S_GMSA_IMAGE"; exit $$STATUS; fi; \
+	  REMOTE_IMG_ID=$$(docker exec kube-master docker image inspect "$$K8S_GMSA_IMAGE" -f '{{ .Id }}' 2> /dev/null); \
+	  if [[ $$? == 0 ]] && [[ "$$REMOTE_IMG_ID" == "$$LOCAL_IMG_ID" ]]; then \
+	    echo "Image $$K8S_GMSA_IMAGE already up-to-date in DIND cluster"; \
+	  else \
+		  echo "Copying image $$K8S_GMSA_IMAGE to DIND cluster..." \
+		    && CMD="$(KUBEADM_DIND_CLUSTER_SCRIPT) copy-image $$K8S_GMSA_IMAGE" \
+		    && echo "$$CMD" && eval "$$CMD"; \
+	  fi
+
+$(KUBEADM_DIND_CLUSTER_SCRIPT):
+	mkdir -p $(dir $(KUBEADM_DIND_CLUSTER_SCRIPT))
+ifeq ($(WGET),)
+	$(CURL) -L $(KUBEADM_DIND_CLUSTER_SCRIPT_URL) > $(KUBEADM_DIND_CLUSTER_SCRIPT)
+else
+	$(WGET) -O $(KUBEADM_DIND_CLUSTER_SCRIPT) $(KUBEADM_DIND_CLUSTER_SCRIPT_URL)
+endif
+	chmod +x $(KUBEADM_DIND_CLUSTER_SCRIPT)

--- a/admission-webhook/make/image.mk
+++ b/admission-webhook/make/image.mk
@@ -1,9 +1,7 @@
-GO_VERSION = 1.11.5
-DOCKER_BUILD = docker build . --build-arg GO_VERSION=$(GO_VERSION)
-
-DEV_IMAGE_NAME = k8s-windows-gmsa-webhook-dev
-# FIXME: find a better way to distribute/publish this image
-IMAGE_NAME = wk88/k8s-gmsa-webhook:latest
+# must stay consistent with the go version defined in .travis.yml
+GO_VERSION = 1.12
+VERSION = $(shell git rev-parse HEAD)
+DOCKER_BUILD = docker build . --build-arg GO_VERSION=$(GO_VERSION) --build-arg VERSION=$(VERSION)
 
 .PHONY: image_build_dev
 image_build_dev:

--- a/admission-webhook/version.go
+++ b/admission-webhook/version.go
@@ -1,0 +1,11 @@
+package main
+
+var version string
+
+func getVersion() string {
+	if version == "" {
+		return "unknown"
+	}
+
+	return version
+}


### PR DESCRIPTION
And running them as part of Travis builds, on the last 3 Kubernetes versions.

Also adds a `dev_cluster.mk` file to make it easy to dev on this repo (allows
easily standing up a throw-away local cluster and handles all the needed
interactions with that cluster).

Signed-off-by: Jean Rouge <rougej+github@gmail.com>