### PR TITLE
Fixing a small bug in the deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - T=integration KUBERNETES_VERSION=1.13
   - T=integration DEPLOY_METHOD=download
   - T=integration WITH_DEV_IMAGE=1
+  - T=dry_run_deploy
 
 install:
   - curl https://glide.sh/get | sh

--- a/admission-webhook/deploy/.helpers.sh
+++ b/admission-webhook/deploy/.helpers.sh
@@ -69,7 +69,11 @@ wait_for() {
         sleep 1
     done
 
-    fatal_error "$ERROR_MSG, giving up after $MAX_ATTEMPTS attempts - last attempt's output: $OUTPUT"
+    local MSG="$ERROR_MSG, giving up after $MAX_ATTEMPTS attempts"
+    if [ "$OUTPUT" ]; then
+        MSG+=" - last attempt's output: $OUTPUT"
+    fi
+    fatal_error "$MSG"
 }
 
 SERVER_KEY="$CERTS_DIR/server-key.pem"

--- a/admission-webhook/deploy/create-signed-cert.sh
+++ b/admission-webhook/deploy/create-signed-cert.sh
@@ -126,7 +126,7 @@ EOF
 echo_or_run --with-kubectl-dry-run "$KUBECTL create -f - <<< '$CSR_CONTENTS'"
 
 if ! $DRY_RUN; then
-    verify_csr_created() { $KUBECTL get csr "$CSR_NAME"; }
+    verify_csr_created() { $KUBECTL get csr "$CSR_NAME" 2>&1 ; }
     wait_for verify_csr_created "CSR $CSR_NAME not properly created"
 fi
 


### PR DESCRIPTION
The deploy script currently always checks if the webhook is up and running,
even for a dry run, which is obviously a bug. Fixed that and added a travis
test to ensure that dry runs function as expected, as this might be a more
important feature than it appears at first glance - people will most likely
want to use dry runs as a way to double check everything before actually
deploying.

There also was another small bug, namely in the way the script checks that the
webhook is up and running: that was using the specific setup we use for dev
(with a DinD k8s cluster), which won't work on any cluster out there. Changed
that to rely on k8s' readiness probe instead.