### PR TITLE
Add the GMSA CRD YAML

### DIFF
--- a/CRD/gmsa-crd.yaml
+++ b/CRD/gmsa-crd.yaml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: gmsacredentialspecs.windows.k8s.io
+spec:
+  group: windows.k8s.io
+  version: v1alpha1
+  names:
+    kind: GMSACredentialSpec
+    plural: gmsacredentialspecs
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        credspec:
+          description: GMSA Credential Spec
+          type: object


### PR DESCRIPTION
Commit the GMSA CRD YAML as a standard place docs can refer to. When we move to beta, this CRD should be moved under: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/