### PR TITLE
Adding a --tolerate-master flag to the webhook deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - T=integration KUBERNETES_VERSION=1.15
   - T=integration DEPLOY_METHOD=download
   - T=integration WITH_DEV_IMAGE=1
+  - T=integration NUM_NODES=0 EXTRA_GMSA_DEPLOY_ARGS=--tolerate-master
   - T=dry_run_deploy
 
 install:

--- a/admission-webhook/deploy/gmsa-webhook.yml.tpl
+++ b/admission-webhook/deploy/gmsa-webhook.yml.tpl
@@ -81,7 +81,7 @@ spec:
     spec:
       serviceAccountName: ${NAME}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        beta.kubernetes.io/os: linux${TOLERATIONS}
       containers:
       - name: ${NAME}
         image: ${IMAGE_NAME}

--- a/admission-webhook/integration_tests/kube.go
+++ b/admission-webhook/integration_tests/kube.go
@@ -33,6 +33,27 @@ func kubeClient(t *testing.T) kubernetes.Interface {
 	return client
 }
 
+// getNodes returns the nodes present in the cluster.
+func getNodes(t *testing.T) []corev1.Node {
+	client := kubeClient(t)
+
+	nodeList, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return nodeList.Items
+}
+
+// nodeHasMasterTaint returns true iff node has the canonical master taint.
+func nodeHasMasterTaint(node corev1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == "node-role.kubernetes.io/master" && taint.Effect == "NoSchedule" {
+			return true
+		}
+	}
+	return false
+}
+
 // waitForPodToComeUp waits for a pod matching `selector` to come up in `namespace`, and returns it.
 func waitForPodToComeUp(t *testing.T, namespace, selector string, pollOps ...poll.SettingOp) *corev1.Pod {
 	fetcher := func(client kubernetes.Interface, listOptions metav1.ListOptions) ([]interface{}, error) {

--- a/admission-webhook/integration_tests/templates/several-containers-with-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/several-containers-with-gmsa.yml
@@ -34,3 +34,6 @@ spec:
         securityContext:
           windowsOptions:
             gmsaCredentialSpecName: {{ index .CredSpecNames 2 }}
+{{- range $line := .ExtraSpecLines }}
+      {{ $line }}
+{{- end }}

--- a/admission-webhook/integration_tests/templates/simple-with-container-level-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-container-level-gmsa.yml
@@ -24,3 +24,6 @@ spec:
         securityContext:
           windowsOptions:
             gmsaCredentialSpecName: {{ index .CredSpecNames 0 }}
+{{- range $line := .ExtraSpecLines }}
+      {{ $line }}
+{{- end }}

--- a/admission-webhook/integration_tests/templates/simple-with-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-gmsa.yml
@@ -24,3 +24,6 @@ spec:
       containers:
       - image: k8s.gcr.io/pause
         name: nginx
+{{- range $line := .ExtraSpecLines }}
+      {{ $line }}
+{{- end }}

--- a/admission-webhook/integration_tests/templates/simple-with-pre-set-matching-contents.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-pre-set-matching-contents.yml
@@ -25,3 +25,6 @@ spec:
       containers:
       - image: k8s.gcr.io/pause
         name: nginx
+{{- range $line := .ExtraSpecLines }}
+      {{ $line }}
+{{- end }}

--- a/admission-webhook/integration_tests/templates/simple-with-pre-set-unmatching-contents.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-pre-set-unmatching-contents.yml
@@ -26,3 +26,6 @@ spec:
       containers:
       - image: k8s.gcr.io/pause
         name: nginx
+{{- range $line := .ExtraSpecLines }}
+      {{ $line }}
+{{- end }}

--- a/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-container-level-contents.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-container-level-contents.yml
@@ -24,3 +24,6 @@ spec:
         securityContext:
           windowsOptions:
             gmsaCredentialSpec: '{"ActiveDirectoryConfig":{"GroupManagedServiceAccounts":[{"Name":"WebApplication0","Scope":"CONTOSO"},{"Name":"WebApplication0","Scope":"contoso.com"}]},"CmsPlugins":["ActiveDirectory"],"DomainJoinConfig":{"DnsName":"contoso.com","DnsTreeName":"contoso.com","Guid":"244818ae-87ca-4fcd-92ec-e79e5252348a","MachineAccountName":"WebApplication0","NetBiosName":"CONTOSO","Sid":"S-1-5-21-2126729477-2524075714-3094792973"}}'
+{{- range $line := .ExtraSpecLines }}
+      {{ $line }}
+{{- end }}

--- a/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-pod-level-contents.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-pod-level-contents.yml
@@ -24,3 +24,6 @@ spec:
       containers:
       - image: k8s.gcr.io/pause
         name: nginx
+{{- range $line := .ExtraSpecLines }}
+      {{ $line }}
+{{- end }}

--- a/admission-webhook/integration_tests/templates/simple-with-unknown-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-unknown-gmsa.yml
@@ -24,3 +24,6 @@ spec:
       containers:
       - image: k8s.gcr.io/pause
         name: nginx
+{{- range $line := .ExtraSpecLines }}
+      {{ $line }}
+{{- end }}

--- a/admission-webhook/integration_tests/templates/single-pod-with-container-level-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/single-pod-with-container-level-gmsa.yml
@@ -20,3 +20,6 @@ spec:
 {{- end }}
   dnsPolicy: ClusterFirst
   restartPolicy: Never
+{{- range $line := .ExtraSpecLines }}
+  {{ $line }}
+{{- end }}

--- a/admission-webhook/integration_tests/templates/single-pod-with-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/single-pod-with-gmsa.yml
@@ -24,3 +24,6 @@ spec:
 {{- end }}
   dnsPolicy: ClusterFirst
   restartPolicy: Never
+{{- range $line := .ExtraSpecLines }}
+  {{ $line }}
+{{- end }}


### PR DESCRIPTION
So that GMSAs can be used in clusters where the only Linux nodes are
masters.

Also added a new Travis suite to run integration tests on a one-node
cluster (i.e. only the master).

Signed-off-by: Jean Rouge <rougej+github@gmail.com>