### PR TITLE
Replacing kubeadm-dind with kind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 
 env:
   - T=unit
-  - T=integration KUBERNETES_VERSION=1.15
+  - T=integration
   - T=integration DEPLOY_METHOD=download
   - T=integration WITH_DEV_IMAGE=1
   - T=integration NUM_NODES=0 EXTRA_GMSA_DEPLOY_ARGS=--tolerate-master

--- a/admission-webhook/.dockerignore
+++ b/admission-webhook/.dockerignore
@@ -1,0 +1,2 @@
+/dev/
+/integration_tests/tmp/

--- a/admission-webhook/Makefile
+++ b/admission-webhook/Makefile
@@ -1,6 +1,8 @@
 .DEFAULT_GOAL := test
 SHELL := /bin/bash
 
+WEBHOOK_ROOT := $(CURDIR)
+
 DEV_IMAGE_NAME = k8s-windows-gmsa-webhook-dev
 # FIXME: find a better way to distribute/publish this image
 IMAGE_NAME = wk88/k8s-gmsa-webhook:latest
@@ -12,15 +14,21 @@ ifeq ($(CURL)$(WGET),)
 $(error "Neither curl nor wget available")
 endif
 
+UNAME = $(shell uname | tr A-Z a-z)
+ifeq ($(UNAME),)
+$(error "Unable to determine OS type")
+endif
+
 include make/*.mk
 
 .PHONY: test
 test: unit_tests integration_tests
 
-# the UNIT_TEST_FLAGS env var can be set to eg run only specific tests
+# the UNIT_TEST_FLAGS env var can be set to eg run only specific tests, e.g:
+# UNIT_TEST_FLAGS='-test.run TestHTTPWebhook' make unit_tests
 .PHONY: unit_tests
 unit_tests:
-	go test -v -count=1 -cover "$$UNIT_TEST_FLAGS"
+	go test -v -count=1 -cover $(UNIT_TEST_FLAGS)
 
 .PHONY: integration_tests
 integration_tests: image_build deploy_webhook run_integration_tests
@@ -28,15 +36,16 @@ integration_tests: image_build deploy_webhook run_integration_tests
 .PHONY: integration_tests_with_dev_image
 integration_tests_with_dev_image: image_build_dev deploy_dev_webhook run_integration_tests
 
-# the INTEGRATION_TEST_FLAGS env var can be set to eg run only specific tests
+# the INTEGRATION_TEST_FLAGS env var can be set to eg run only specific tests, e.g.:
+# INTEGRATION_TEST_FLAGS='-test.run TestHappyPathWithPodLevelCredSpec' make run_integration_tests
 .PHONY: run_integration_tests
 run_integration_tests:
 	@ echo "### Starting integration tests with Kubernetes version: $(KUBERNETES_VERSION) ###"
-	cd integration_tests && KUBECTL=$(KUBECTL) go test -count 1 -v "$$INTEGRATION_TEST_FLAGS"
+	cd integration_tests && KUBECONFIG=$(KUBECONFIG) KUBECTL=$(KUBECTL) go test -count 1 -v $(INTEGRATION_TEST_FLAGS)
 
 .PHONY: clean_integration_tests
 clean_integration_tests:
 	rm -rf integration_tests/tmp
 
 .PHONY: clean
-clean: clean_cluster clean_integration_tests
+clean: cluster_clean clean_integration_tests

--- a/admission-webhook/integration_tests/templates/several-containers-with-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/several-containers-with-gmsa.yml
@@ -1,6 +1,6 @@
 ## a simple deployment with several containers: 2 with their own GMSA, and 1 without it, plus a pod-level cred spec
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/admission-webhook/integration_tests/templates/simple-with-container-level-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-container-level-gmsa.yml
@@ -1,6 +1,6 @@
 ## a simple deployment with a container-level GMSA cred spec
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/admission-webhook/integration_tests/templates/simple-with-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-gmsa.yml
@@ -1,6 +1,6 @@
 ## a simple deployment with a pod-level GMSA cred spec
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/admission-webhook/integration_tests/templates/simple-with-pre-set-matching-contents.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-pre-set-matching-contents.yml
@@ -1,6 +1,6 @@
 ## a simple deployment with a fully specified GMSA cred spec (ie both its name and contents)
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/admission-webhook/integration_tests/templates/simple-with-pre-set-unmatching-contents.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-pre-set-unmatching-contents.yml
@@ -1,7 +1,7 @@
 ## a simple deployment with a fully specified GMSA cred spec (ie both its name and contents);
 ## but where the specified contents don't match the name
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-container-level-contents.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-container-level-contents.yml
@@ -1,6 +1,6 @@
 ## a simple deployment with a container-level cred spec GMSA's *contents* already set (and not its name)
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-pod-level-contents.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-preset-gmsa-pod-level-contents.yml
@@ -1,6 +1,6 @@
 ## a simple deployment with a pod-level cred spec GMSA's *contents* already set (and not its name)
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/admission-webhook/integration_tests/templates/simple-with-unknown-gmsa.yml
+++ b/admission-webhook/integration_tests/templates/simple-with-unknown-gmsa.yml
@@ -1,6 +1,6 @@
 ## a simple deployment trying to use a pod-level GMSA cred spec that doesn't exist
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/admission-webhook/make/dev_cluster.mk
+++ b/admission-webhook/make/dev_cluster.mk
@@ -1,93 +1,102 @@
 # K8S version can be overriden
-KUBERNETES_VERSION ?= 1.15
-# see https://github.com/wk8/kubeadm-dind-cluster/releases
-KUBEADM_DIND_VERSION = v0.3.0
+# see available versions at https://hub.docker.com/r/kindest/node/tags
+KUBERNETES_VERSION ?= 1.16.1
+# see https://github.com/kubernetes-sigs/kind/releases
+KIND_VERSION = 0.5.1
 
-ifeq ($(filter $(KUBERNETES_VERSION),1.15),)
+ifeq ($(filter $(KUBERNETES_VERSION),1.16.1),)
 $(error "Kubernetes version $(KUBERNETES_VERSION) not supported")
 endif
 
+CLUSTER_NAME ?= windows-gmsa-dev
 DEPLOYMENT_NAME ?= windows-gmsa-dev
 NAMESPACE ?= windows-gmsa-dev
 NUM_NODES ?= 1
 
-# kubeadm DinD settings
-# FIXME: switch to KIND, see
-# https://github.com/kubernetes-sigs/windows-gmsa/issues/12
-KUBEADM_DIND_CLUSTER_SCRIPT = dev/kubeadm_dind_scripts/$(KUBEADM_DIND_VERSION)/dind-cluster-v$(KUBERNETES_VERSION).sh
-KUBEADM_DIND_CLUSTER_SCRIPT_URL = https://github.com/wk8/kubeadm-dind-cluster/releases/download/$(KUBEADM_DIND_VERSION)/dind-cluster-v$(KUBERNETES_VERSION).sh
-KUBEADM_DIND_DIR = ~/.kubeadm-dind-cluster
-ADMISSION_PLUGINS = NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+DEV_DIR = $(WEBHOOK_ROOT)/dev
 
-KUBECTL = $(KUBEADM_DIND_DIR)/kubectl
-CERTS_DIR = dev/certs_dir
-MANIFESTS_FILE = dev/gmsa-webhook.yml
+CERTS_DIR = $(DEV_DIR)/certs_dir
+MANIFESTS_FILE = $(DEV_DIR)/gmsa-webhook.yml
 
-# starts a new DinD cluster (see https://github.com/wk8/kubeadm-dind-cluster)
+KIND = $(DEV_DIR)/kind-$(KIND_VERSION)
+KIND_URL = https://github.com/kubernetes-sigs/kind/releases/download/v$(KIND_VERSION)/kind-$(UNAME)-amd64
+
+KUBECTL = $(shell which kubectl 2> /dev/null)
+KUBECTL_URL = https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/$(UNAME)/amd64/kubectl
+
+ifeq ($(KUBECTL),)
+KUBECTL = $(DEV_DIR)/kubectl-$(KUBERNETES_VERSION)
+endif
+
+KUBECONFIG = ~/.kube/kind-config-$(CLUSTER_NAME)
+
+# starts a new kind cluster (see https://github.com/kubernetes-sigs/kind)
 .PHONY: cluster_start
-cluster_start: $(KUBEADM_DIND_CLUSTER_SCRIPT)
-	NUM_NODES=$(NUM_NODES) SKIP_DASHBOARD=1 FEATURE_GATES='WindowsGMSA=true' APISERVER_enable_admission_plugins=$(ADMISSION_PLUGINS) $(KUBEADM_DIND_CLUSTER_SCRIPT) up
-	@ echo "### Kubectl version: ###"
-	$(KUBECTL) version
-	# known issue with kubeadm-dind
-	# TODO: remove this when we migrate to kind
-	$(KUBECTL) delete -n kube-system deployment.apps/coredns
-	# also, kubeadm-dind removes the taint on master when NUM_NODES is 0 - but we do want to test that case too!
-	$(KUBECTL) taint node kube-master 'node-role.kubernetes.io/master=true:NoSchedule' --overwrite
+cluster_start: $(KIND) $(KUBECTL)
+	./make/start_cluster.sh --name '$(CLUSTER_NAME)' --num-nodes $(NUM_NODES) --version $(KUBERNETES_VERSION) --kind-bin "$(KIND)"
+	@ echo '### Kubectl version: ###'
+	KUBECONFIG=$(KUBECONFIG) $(KUBECTL) version
+	# coredns has a thing for creating API resources continually, which confuses the dry-run test
+	# since it's not needed for anything here, there's no reason to keep it around
+	KUBECONFIG=$(KUBECONFIG) $(KUBECTL) delete -n kube-system deployment.apps/coredns
+	# kind removes the taint on master when NUM_NODES is 0 - but we do want to test that case too!
+	KUBECONFIG=$(KUBECONFIG) $(KUBECTL) taint node $(CLUSTER_NAME)-control-plane 'node-role.kubernetes.io/master=true:NoSchedule' --overwrite
+	@ echo -e 'Cluster started, KUBECONFIG available at $(KUBECONFIG), eg\nexport KUBECONFIG=$(KUBECONFIG)'
+	@ $(MAKE) cluster_symlinks
 
-# stops the DinD cluster
-.PHONY: cluster_stop
-cluster_stop: $(KUBEADM_DIND_CLUSTER_SCRIPT)
-	$(KUBEADM_DIND_CLUSTER_SCRIPT) down
-
-# removes the DinD cluster
-.PHONY: clean_cluster
-clean_cluster: clean_certs cluster_stop
-	$(KUBEADM_DIND_CLUSTER_SCRIPT) clean
-	rm -rf $(KUBEADM_DIND_DIR)
+# removes the kind cluster
+.PHONY: cluster_clean
+cluster_clean: $(KIND) clean_certs
+	$(KIND) delete cluster --name '$(CLUSTER_NAME)'
 
 .PHONY: clean_certs
 clean_certs:
 	rm -rf $(CERTS_DIR)
 
-# deploys the webhook to the DinD cluster with the dev image
+# deploys the webhook to the kind cluster with the dev image
 .PHONY: deploy_dev_webhook
 deploy_dev_webhook:
 	K8S_GMSA_IMAGE=$(DEV_IMAGE_NAME) $(MAKE) _deploy_webhook
 
-# deploys the webhook to the DinD cluster with the release image
+# deploys the webhook to the kind cluster with the release image
 .PHONY: deploy_webhook
 deploy_webhook:
 	K8S_GMSA_IMAGE=$(IMAGE_NAME) $(MAKE) _deploy_webhook
 
-# removes the webhook from the DinD cluster
+# removes the webhook from the kind cluster
 .PHONY: remove_webhook
 remove_webhook:
 ifeq ($(wildcard $(MANIFESTS_FILE)),)
 	@ echo "No manifests file found at $(MANIFESTS_FILE), nothing to remove"
 else
-	$(KUBECTL) delete -f $(MANIFESTS_FILE) || true
+	KUBECONFIG=$(KUBECONFIG) $(KUBECTL) delete -f $(MANIFESTS_FILE) || true
 endif
+
+# cluster_symlinks symlinks kubectl to dev/kubectl, and the kube config to dev/kubeconfig
+.PHONY:
+cluster_symlinks:
+	ln -sfv $(KUBECTL) $(DEV_DIR)/kubectl
+	ln -sfv $(KUBECONFIG) $(DEV_DIR)/kubeconfig
 
 ### "Private" targets below ###
 
-# starts the DinD cluster only if it's not already running
+# starts the kind cluster only if it's not already running
 .PHONY: _start_cluster_if_not_running
-_start_cluster_if_not_running: $(KUBEADM_DIND_CLUSTER_SCRIPT)
-	@ if [ -x $(KUBECTL) ] && timeout 2 $(KUBECTL) version &> /dev/null; then \
+_start_cluster_if_not_running: $(KUBECTL) $(KIND)
+	@ if KUBECONFIG=$(KUBECONFIG) timeout 2 $(KUBECTL) version &> /dev/null; then \
 		echo "Dev cluster already running"; \
 	else \
 		$(MAKE) cluster_start; \
 	fi
 
-# deploys the webhook to the DinD cluster
+# deploys the webhook to the kind cluster
 # if $K8S_GMSA_DEPLOY_METHOD is set to "download", then it will deploy by downloading
 # the deploy script as documented in the README, using $K8S_GMSA_DEPLOY_DOWNLOAD_REPO and
 # $K8S_GMSA_DEPLOY_DOWNLOAD_REV env variables to build the download URL. If those two are not
 # set, it will try to infer them from the current's branch remote branch and the current
 # HEAD's SHA.
 .PHONY: _deploy_webhook
-_deploy_webhook: _copy_image_if_needed remove_webhook
+_deploy_webhook: _copy_image remove_webhook
 ifeq ($(K8S_GMSA_IMAGE),)
 	@ echo "Cannot call target $@ without setting K8S_GMSA_IMAGE"
 	exit 1
@@ -106,35 +115,35 @@ ifeq ($(K8S_GMSA_DEPLOY_METHOD),download)
         [ "$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO" ] || K8S_GMSA_DEPLOY_DOWNLOAD_REPO='kubernetes-sigs/windows-gmsa'; \
       fi \
       && if [ ! "$$K8S_GMSA_DEPLOY_DOWNLOAD_REV" ]; then K8S_GMSA_DEPLOY_DOWNLOAD_REV="$$(git rev-parse HEAD)"; fi \
-      && CMD="curl -sL 'https://raw.githubusercontent.com/$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO/$$K8S_GMSA_DEPLOY_DOWNLOAD_REV/admission-webhook/deploy/deploy-gmsa-webhook.sh' | K8S_GMSA_DEPLOY_DOWNLOAD_REPO='$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO' K8S_GMSA_DEPLOY_DOWNLOAD_REV='$$K8S_GMSA_DEPLOY_DOWNLOAD_REV' KUBECTL=$(KUBECTL) bash -s -- --file '$(MANIFESTS_FILE)' --name '$(DEPLOYMENT_NAME)' --namespace '$(NAMESPACE)' --image '$(K8S_GMSA_IMAGE)' --certs-dir '$(CERTS_DIR)' $(EXTRA_GMSA_DEPLOY_ARGS)" \
+      && CMD="curl -sL 'https://raw.githubusercontent.com/$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO/$$K8S_GMSA_DEPLOY_DOWNLOAD_REV/admission-webhook/deploy/deploy-gmsa-webhook.sh' | K8S_GMSA_DEPLOY_DOWNLOAD_REPO='$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO' K8S_GMSA_DEPLOY_DOWNLOAD_REV='$$K8S_GMSA_DEPLOY_DOWNLOAD_REV' KUBECONFIG=$(KUBECONFIG) KUBECTL=$(KUBECTL) bash -s -- --file '$(MANIFESTS_FILE)' --name '$(DEPLOYMENT_NAME)' --namespace '$(NAMESPACE)' --image '$(K8S_GMSA_IMAGE)' --certs-dir '$(CERTS_DIR)' $(EXTRA_GMSA_DEPLOY_ARGS)" \
       && echo "$$CMD" && eval "$$CMD"
 else
-	KUBECTL=$(KUBECTL) ./deploy/deploy-gmsa-webhook.sh --file "$(MANIFESTS_FILE)" --name "$(DEPLOYMENT_NAME)" --namespace "$(NAMESPACE)" --image "$(K8S_GMSA_IMAGE)" --certs-dir "$(CERTS_DIR)" $(EXTRA_GMSA_DEPLOY_ARGS)
+	KUBECONFIG=$(KUBECONFIG) KUBECTL=$(KUBECTL) ./deploy/deploy-gmsa-webhook.sh --file "$(MANIFESTS_FILE)" --name "$(DEPLOYMENT_NAME)" --namespace "$(NAMESPACE)" --image "$(K8S_GMSA_IMAGE)" --certs-dir "$(CERTS_DIR)" $(EXTRA_GMSA_DEPLOY_ARGS)
 endif
 
-# copies the image to the DinD cluster only if it's not already up-to-date
-.PHONY: _copy_image_if_needed
-_copy_image_if_needed: _start_cluster_if_not_running
+# copies the image to the kind cluster
+.PHONY: _copy_image
+_copy_image: _start_cluster_if_not_running
 ifeq ($(K8S_GMSA_IMAGE),)
 	@ echo "Cannot call target $@ without setting K8S_GMSA_IMAGE"
 	exit 1
 endif
-	@ LOCAL_IMG_ID=$$(docker image inspect "$$K8S_GMSA_IMAGE" -f '{{ .Id }}'); \
-	  STATUS=$$? ; if [[ $$STATUS != 0 ]]; then echo "Unable to retrieve image ID for $$K8S_GMSA_IMAGE"; exit $$STATUS; fi; \
-	  REMOTE_IMG_ID=$$(docker exec kube-master docker image inspect "$$K8S_GMSA_IMAGE" -f '{{ .Id }}' 2> /dev/null); \
-	  if [[ $$? == 0 ]] && [[ "$$REMOTE_IMG_ID" == "$$LOCAL_IMG_ID" ]]; then \
-	    echo "Image $$K8S_GMSA_IMAGE already up-to-date in DIND cluster"; \
-	  else \
-		  echo "Copying image $$K8S_GMSA_IMAGE to DIND cluster..." \
-		    && CMD="$(KUBEADM_DIND_CLUSTER_SCRIPT) copy-image $$K8S_GMSA_IMAGE" \
-		    && echo "$$CMD" && eval "$$CMD"; \
-	  fi
+	$(KIND) load docker-image $(K8S_GMSA_IMAGE) --name '$(CLUSTER_NAME)'
 
-$(KUBEADM_DIND_CLUSTER_SCRIPT):
-	mkdir -p $(dir $(KUBEADM_DIND_CLUSTER_SCRIPT))
+$(KIND):
+	mkdir -vp "$$(dirname $(KIND))"
 ifeq ($(WGET),)
-	$(CURL) -L $(KUBEADM_DIND_CLUSTER_SCRIPT_URL) > $(KUBEADM_DIND_CLUSTER_SCRIPT)
+	$(CURL) -L $(KIND_URL) > $(KIND)
 else
-	$(WGET) -O $(KUBEADM_DIND_CLUSTER_SCRIPT) $(KUBEADM_DIND_CLUSTER_SCRIPT_URL)
+	$(WGET) -O $(KIND) $(KIND_URL)
 endif
-	chmod +x $(KUBEADM_DIND_CLUSTER_SCRIPT)
+	chmod +x $(KIND)
+
+$(KUBECTL):
+	mkdir -vp "$$(dirname $(KUBECTL))"
+ifeq ($(WGET),)
+	$(CURL) -L $(KUBECTL_URL) > $(KUBECTL)
+else
+	$(WGET) -O $(KUBECTL) $(KUBECTL_URL)
+endif
+	chmod +x $(KUBECTL)

--- a/admission-webhook/make/start_cluster.sh
+++ b/admission-webhook/make/start_cluster.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -e
+
+usage() {
+    cat <<EOF
+Light wrapper around kind that generates the right configuration file for kind, then starts the cluster.
+
+usage: $0 --name NAME --num-nodes NUM_NODES --version VERSION [--kind-bin KIND_BIN]
+
+NAME is the kind cluster name.
+NUM_NODES is the number of worker nodes.
+VERSION is the k8s version to use.
+KIND_BIN is the path to the kind executable.
+EOF
+    exit 1
+}
+
+main() {
+    local NAME=
+    local NUM_NODES=
+    local VERSION=
+    local KIND_BIN=kind
+
+    # parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --name)
+                NAME="$2" ;;
+            --num-nodes)
+                NUM_NODES="$2" ;;
+            --version)
+                VERSION="$2" ;;
+            --kind-bin)
+                KIND_BIN="$2" ;;
+            *)
+                echo "Unknown option: $1"
+                usage ;;
+        esac
+        shift 2
+    done
+
+    [ "$NAME" ] && [ "$NUM_NODES" ] && [ "$VERSION" ] || usage
+
+    local CONFIG_FILE
+    CONFIG_FILE="$(mktemp /tmp/gmsa-webhook-kind-config.XXXXXXX)"
+
+    # generate the config file
+    cat <<EOF > "$CONFIG_FILE"
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+kubeadmConfigPatches:
+- |
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      enable-admission-plugins: NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+EOF
+    cat <<EOF >> "$CONFIG_FILE"
+nodes:
+- role: control-plane
+EOF
+    for _ in $(seq "$NUM_NODES"); do
+        echo -e '- role: worker' >> "$CONFIG_FILE"
+    done
+
+    # run kind
+    local EXIT_STATUS=0
+    $KIND_BIN create cluster --name "$NAME" --config "$CONFIG_FILE" --image "kindest/node:v$VERSION" --wait 240s || EXIT_STATUS=$?
+
+    # clean up the config file
+    rm -f "$CONFIG_FILE"
+
+    return $EXIT_STATUS
+}
+
+main "$@"


### PR DESCRIPTION
Since the former is being deprecated, and is no longer maintained.

Also made necessary changes to tests to run on k8s v1.16, ie to account
for API changes that were introduced in that version.

Resolves https://github.com/kubernetes-sigs/windows-gmsa/issues/12.

Signed-off-by: Jean Rouge <rougej+github@gmail.com>