### PR TITLE
Fix KUBECTL not being executable during e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - T=integration DEPLOY_METHOD=download
   - T=integration WITH_DEV_IMAGE=1
   - T=integration NUM_NODES=0 EXTRA_GMSA_DEPLOY_ARGS=--tolerate-master
+  - T=integration WITHOUT_ENVSUBST=1
   - T=dry_run_deploy
 
 install:

--- a/admission-webhook/.travis.sh
+++ b/admission-webhook/.travis.sh
@@ -23,6 +23,10 @@ main() {
 }
 
 run_integration_tests() {
+    if [ "$WITHOUT_ENVSUBST" ] && [ -x "$(command -v envsubst)" ] && [[ "$TRAVIS" == "true" ]]; then
+        sudo rm -f "$(command -v envsubst)"
+    fi
+
     if [[ "$DEPLOY_METHOD" == 'download' ]]; then
         export K8S_GMSA_DEPLOY_METHOD='download'
 

--- a/admission-webhook/deploy/.helpers.sh
+++ b/admission-webhook/deploy/.helpers.sh
@@ -30,11 +30,12 @@ fatal_error() {
     exit 1
 }
 
-if [ ! "$KUBECTL" ]; then
-    KUBECTL=$(which kubectl) || true
-fi
-if [ ! -x $KUBECTL ]; then
-    fatal_error 'kubectl not found'
+if [ ! -x "$KUBECTL" ]; then
+    KUBECTL=$(command -v kubectl)
+
+    if [ ! -x "$KUBECTL" ]; then
+        fatal_error 'kubectl not found'
+    fi
 fi
 
 echo_or_run() {


### PR DESCRIPTION
Use a docker container for running envsubst if envsubst is not available
Add travis job without envsubst
Always return an absolute path in ensure_helper_file_present

Squashed version of #21 