### PR TITLE
Updates for gmsa webhook for k8s version 1.22

### DIFF
--- a/admission-webhook/Makefile
+++ b/admission-webhook/Makefile
@@ -4,8 +4,9 @@ SHELL := /bin/bash
 WEBHOOK_ROOT := $(CURDIR)
 
 DEV_IMAGE_NAME = k8s-windows-gmsa-webhook-dev
-# FIXME: find a better way to distribute/publish this image
-IMAGE_NAME = wk88/k8s-gmsa-webhook:latest
+VERSION = $(shell git describe --tags --always `git rev-parse HEAD`)
+IMAGE_REPO = sigwindowstools/k8s-gmsa-webhook
+IMAGE_NAME = $(IMAGE_REPO):$(VERSION)
 
 CURL = $(shell which curl 2> /dev/null)
 WGET = $(shell which wget 2> /dev/null)

--- a/admission-webhook/deploy/create-signed-cert.sh
+++ b/admission-webhook/deploy/create-signed-cert.sh
@@ -98,7 +98,7 @@ EOF
 gen_file gen_csr_conf "$CSR_CONF"
 
 SERVER_CSR="$CERTS_DIR/server.csr"
-gen_server_scr() { openssl req -new -key "$SERVER_KEY" -subj "/CN=$SERVICE.$NAMESPACE.svc" -out "$SERVER_CSR" -config "$CSR_CONF"; }
+gen_server_scr() { openssl req -new -key "$SERVER_KEY" -subj "/O=system:nodes/CN=system:node:$SERVICE.$NAMESPACE.svc" -out "$SERVER_CSR" -config "$CSR_CONF"; }
 gen_file gen_server_scr "$SERVER_CSR"
 
 CSR_NAME="$SERVICE.$NAMESPACE"
@@ -109,7 +109,7 @@ fi
 
 # create server cert/key CSR and send to k8s API
 CSR_CONTENTS=$(cat <<EOF
-apiVersion: certificates.k8s.io/v1beta1
+apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
   name: $CSR_NAME
@@ -117,6 +117,7 @@ spec:
   groups:
   - system:authenticated
   request: $(cat "$SERVER_CSR" | base64 -w 0)
+  signerName: kubernetes.io/kubelet-serving
   usages:
   - digital signature
   - key encipherment

--- a/admission-webhook/deploy/deploy-gmsa-webhook.sh
+++ b/admission-webhook/deploy/deploy-gmsa-webhook.sh
@@ -22,7 +22,7 @@ usage: $0 --file MANIFESTS_FILE [--name NAME] [--namespace NAMESPACE] [--image I
 MANIFESTS_FILE is the path to the file the k8s manifests will be written to.
 NAME defaults to 'gmsa-webhook' and is used in the names of most of the k8s resources created.
 NAMESPACE is the namespace to deploy to; defaults to 'gmsa-webhook'.
-IMAGE_NAME is the name of the Docker image containing the webhook; defaults to 'wk88/k8s-gmsa-webhook:latest' (FIXME: figure out a better way to distribute this image)
+IMAGE_NAME is the name of the Docker image containing the webhook; defaults to 'sigwindowstools/k8s-gmsa-webhook:latest'
 CERTS_DIR defaults to 'gmsa-webhook-certs'
 
 If --dry-run is set, the script echoes what command it would perform
@@ -82,7 +82,7 @@ main() {
     local MANIFESTS_FILE=
     local NAME='gmsa-webhook'
     local NAMESPACE='gmsa-webhook'
-    local IMAGE_NAME='wk88/k8s-gmsa-webhook:latest'
+    local IMAGE_NAME='sigwindowstools/k8s-gmsa-webhook:latest'
     local CERTS_DIR='gmsa-webhook-certs'
     local DRY_RUN=false
     local OVERWRITE=false

--- a/admission-webhook/deploy/gmsa-crd.yml
+++ b/admission-webhook/deploy/gmsa-crd.yml
@@ -1,17 +1,55 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: gmsacredentialspecs.windows.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/689-windows-gmsa"
 spec:
   group: windows.k8s.io
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          credspec:
+            description: GMSA Credential Spec
+            type: object
+            properties:
+              ActiveDirectoryConfig:
+                type: object
+                properties:
+                  GroupManagedServiceAccounts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        Name:
+                          type: string
+                        Scope:
+                          type: string
+              CmsPlugins:
+                type: array
+                items:
+                  type: string
+              DomainJoinConfig:
+                type: object
+                properties:
+                  DnsName:
+                    type: string
+                  DnsTreeName:
+                    type: string
+                  Guid:
+                    type: string
+                  MachineAccountName:
+                    type: string
+                  NetBiosName:
+                    type: string
+                  Sid:
+                    type: string
   names:
     kind: GMSACredentialSpec
     plural: gmsacredentialspecs
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        credspec:
-          description: GMSA Credential Spec
-          type: object

--- a/admission-webhook/deploy/gmsa-webhook.yml.tpl
+++ b/admission-webhook/deploy/gmsa-webhook.yml.tpl
@@ -128,7 +128,7 @@ spec:
 
 ---
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: ${NAME}
@@ -146,6 +146,8 @@ webhooks:
     apiVersions: ["*"]
     resources: ["pods"]
   failurePolicy: Fail
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
   # don't run on ${NAMESPACE}
   namespaceSelector:
     matchExpressions:
@@ -155,7 +157,7 @@ webhooks:
 
 ---
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: ${NAME}
@@ -173,6 +175,8 @@ webhooks:
     apiVersions: ["*"]
     resources: ["pods"]
   failurePolicy: Fail
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
   # don't run on ${NAMESPACE}
   namespaceSelector:
     matchExpressions:

--- a/admission-webhook/make/image.mk
+++ b/admission-webhook/make/image.mk
@@ -1,6 +1,5 @@
 # must stay consistent with the go version defined in .travis.yml
 GO_VERSION = 1.16
-VERSION = $(shell git rev-parse HEAD)
 DOCKER_BUILD = docker build . --build-arg GO_VERSION=$(GO_VERSION) --build-arg VERSION=$(VERSION)
 
 .PHONY: image_build_dev
@@ -10,7 +9,9 @@ image_build_dev:
 .PHONY: image_build
 image_build:
 	$(DOCKER_BUILD) -f dockerfiles/Dockerfile -t $(IMAGE_NAME)
+	docker tag $(IMAGE_NAME) $(IMAGE_REPO):latest
 
 .PHONY: image_push
 image_push:
 	docker push $(IMAGE_NAME)
+	docker push $(IMAGE_REPO):latest

--- a/admission-webhook/webhook_http_test.go
+++ b/admission-webhook/webhook_http_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionV1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,8 +28,8 @@ func TestHTTPWebhook(t *testing.T) {
 
 	pod := buildPod(dummyServiceAccoutName, buildWindowsOptions(dummyCredSpecName, ""), map[string]*corev1.WindowsSecurityContextOptions{"container-name": nil})
 
-	admissionRequest := &admissionv1beta1.AdmissionReview{
-		Request: &admissionv1beta1.AdmissionRequest{
+	admissionRequest := &admissionV1.AdmissionReview{
+		Request: &admissionV1.AdmissionRequest{
 			UID: requestUID,
 			Kind: metav1.GroupVersionKind{
 				Version: "v1",
@@ -40,7 +40,7 @@ func TestHTTPWebhook(t *testing.T) {
 				Resource: "pods",
 			},
 			Namespace: dummyNamespace,
-			Operation: admissionv1beta1.Create,
+			Operation: admissionV1.Create,
 			UserInfo: authenticationv1.UserInfo{
 				Username: "system:serviceaccount:kube-system:replicaset-controller",
 				UID:      "cb335ac0-34b4-11e9-9745-06da3a0adce4",
@@ -83,7 +83,7 @@ func TestHTTPWebhook(t *testing.T) {
 		assert.True(t, response.Response.Allowed)
 
 		if assert.NotNil(t, response.Response.PatchType) {
-			assert.Equal(t, admissionv1beta1.PatchTypeJSONPatch, *response.Response.PatchType)
+			assert.Equal(t, admissionV1.PatchTypeJSONPatch, *response.Response.PatchType)
 		}
 
 		var patches []map[string]string
@@ -190,7 +190,7 @@ func startHTTPServer(t *testing.T, kubeClient *dummyKubeClient) (int, func()) {
 	}
 }
 
-func makeHTTPRequest(t *testing.T, port int, method string, path string, admissionRequest *admissionv1beta1.AdmissionReview, headers ...string) (httpCode int, admissionResponse *admissionv1beta1.AdmissionReview) {
+func makeHTTPRequest(t *testing.T, port int, method string, path string, admissionRequest *admissionV1.AdmissionReview, headers ...string) (httpCode int, admissionResponse *admissionV1.AdmissionReview) {
 	require.Equal(t, 0, len(headers)%2, "header names and values should be provided in pairs")
 
 	reqBody, err := json.Marshal(admissionRequest)
@@ -217,7 +217,7 @@ func makeHTTPRequest(t *testing.T, port int, method string, path string, admissi
 	respBody, err := ioutil.ReadAll(resp.Body)
 	require.Nil(t, err)
 
-	admissionResponse = &admissionv1beta1.AdmissionReview{}
+	admissionResponse = &admissionV1.AdmissionReview{}
 	if err := json.Unmarshal(respBody, admissionResponse); err != nil {
 		admissionResponse = nil
 	}

--- a/admission-webhook/webhook_test.go
+++ b/admission-webhook/webhook_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionV1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -227,7 +227,7 @@ func TestMutateCreateRequest(t *testing.T) {
 			assert.True(t, response.Allowed)
 
 			if assert.NotNil(t, response.PatchType) {
-				assert.Equal(t, admissionv1beta1.PatchTypeJSONPatch, *response.PatchType)
+				assert.Equal(t, admissionV1.PatchTypeJSONPatch, *response.PatchType)
 			}
 
 			patchPath := func(kind gmsaResourceKind, name string) string {


### PR DESCRIPTION
~in #29 the certificates.k8s.io/v1 was missing the `signerName`~

This includes all changes from #29 and adds some additional needed updates.  See the comment below: https://github.com/kubernetes-sigs/windows-gmsa/pull/31#issuecomment-848332674

Fixes: https://github.com/kubernetes/kubernetes/issues/102113 #32