### PR TITLE
Use githubs envs instead of travis ci

### DIFF
--- a/admission-webhook/make/dev_cluster.mk
+++ b/admission-webhook/make/dev_cluster.mk
@@ -89,9 +89,8 @@ _start_cluster_if_not_running: $(KUBECTL) $(KIND)
 # deploys the webhook to the kind cluster
 # if $K8S_GMSA_DEPLOY_METHOD is set to "download", then it will deploy by downloading
 # the deploy script as documented in the README, using $K8S_GMSA_DEPLOY_DOWNLOAD_REPO and
-# $K8S_GMSA_DEPLOY_DOWNLOAD_REV env variables to build the download URL. If those two are not
-# set, it will try to infer them from the current's branch remote branch and the current
-# HEAD's SHA.
+# $K8S_GMSA_DEPLOY_DOWNLOAD_REV env variables to build the download URL. If REV is not set the current
+# HEAD's SHA is used.
 .PHONY: _deploy_webhook
 _deploy_webhook: _copy_image remove_webhook
 ifeq ($(K8S_GMSA_IMAGE),)
@@ -100,17 +99,7 @@ ifeq ($(K8S_GMSA_IMAGE),)
 endif
 	mkdir -p $(dir $(MANIFESTS_FILE))
 ifeq ($(K8S_GMSA_DEPLOY_METHOD),download)
-	@ if [ ! "$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO" ]; then \
-        SHORT_UPSTREAM="$$(git for-each-ref --format='%(upstream:short)' "$$(git symbolic-ref -q HEAD)" 2>/dev/null)"; \
-        if [[ $$? == 0 ]]; then \
-          REMOTE_NAME=$${SHORT_UPSTREAM%%/*} ; \
-            REMOTE_URL="$$(git remote get-url "$$REMOTE_NAME" 2>/dev/null)"; \
-            if [[ $$? == 0 ]]; then \
-              REPO_OWNER_AND_NAME=$${REMOTE_URL#*:} && K8S_GMSA_DEPLOY_DOWNLOAD_REPO=$${REPO_OWNER_AND_NAME%.*}; \
-            fi; \
-        fi; \
-        [ "$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO" ] || K8S_GMSA_DEPLOY_DOWNLOAD_REPO='kubernetes-sigs/windows-gmsa'; \
-      fi \
+	@if [ ! "$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO" ]; then K8S_GMSA_DEPLOY_DOWNLOAD_REPO="kubernetes-sigs/windows-gmsa"; fi \
       && if [ ! "$$K8S_GMSA_DEPLOY_DOWNLOAD_REV" ]; then K8S_GMSA_DEPLOY_DOWNLOAD_REV="$$(git rev-parse HEAD)"; fi \
       && CMD="curl -sL 'https://raw.githubusercontent.com/$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO/$$K8S_GMSA_DEPLOY_DOWNLOAD_REV/admission-webhook/deploy/deploy-gmsa-webhook.sh' | K8S_GMSA_DEPLOY_DOWNLOAD_REPO='$$K8S_GMSA_DEPLOY_DOWNLOAD_REPO' K8S_GMSA_DEPLOY_DOWNLOAD_REV='$$K8S_GMSA_DEPLOY_DOWNLOAD_REV' KUBECONFIG=$(KUBECONFIG) KUBECTL=$(KUBECTL) bash -s -- --file '$(MANIFESTS_FILE)' --name '$(DEPLOYMENT_NAME)' --namespace '$(NAMESPACE)' --image '$(K8S_GMSA_IMAGE)' --certs-dir '$(CERTS_DIR)' $(EXTRA_GMSA_DEPLOY_ARGS)" \
       && echo "$$CMD" && eval "$$CMD"

--- a/admission-webhook/run-ci.sh
+++ b/admission-webhook/run-ci.sh
@@ -31,13 +31,16 @@ run_integration_tests() {
     if [[ "$DEPLOY_METHOD" == 'download' ]]; then
         export K8S_GMSA_DEPLOY_METHOD='download'
 
-        if [ "$TRAVIS_COMMIT" ] && [ "$TRAVIS_PULL_REQUEST_SHA" ]; then
-            # it's a pull request
-            export K8S_GMSA_DEPLOY_DOWNLOAD_REPO="$TRAVIS_PULL_REQUEST_SLUG"
-            export K8S_GMSA_DEPLOY_DOWNLOAD_REV="$TRAVIS_PULL_REQUEST_SHA"
+        if [ "GITHUB_HEAD_REF" ]; then
+            # GITHUB_HEAD_REF is only set if it's a pull request
+            export K8S_GMSA_DEPLOY_DOWNLOAD_REPO="$GITHUB_REPOSITORY"
+            export K8S_GMSA_DEPLOY_DOWNLOAD_REV="$GITHUB_SHA"
+            echo "Running pull request: $K8S_GMSA_DEPLOY_DOWNLOAD_REPO $K8S_GMSA_DEPLOY_DOWNLOAD_REV"
         else
             # not a pull request
+            export K8S_GMSA_DEPLOY_DOWNLOAD_REPO="kubernetes-sigs/windows-gmsa"
             export K8S_GMSA_DEPLOY_DOWNLOAD_REV="$(git rev-parse HEAD)"
+            echo "Running: $K8S_GMSA_DEPLOY_DOWNLOAD_REPO $K8S_GMSA_DEPLOY_DOWNLOAD_REV"
         fi
     fi
 


### PR DESCRIPTION
The job `deploy-method-download` was failing because the introspection of the git repo and revision was not working. I've simplified this logic and updated to use githubs ci