### PR TITLE
Use docker when envsubst not present

### DIFF
--- a/.github/actions/tests/action.yaml
+++ b/.github/actions/tests/action.yaml
@@ -4,7 +4,10 @@ runs:
   steps:
     - name: install envsub
       shell: bash
-      run: sudo apt-get update && sudo apt-get -y install gettext-base
+      run: |
+        if [ ! "$WITHOUT_ENVSUBST" ] && [ ! -x "$(command -v envsubst)" ]; then
+          sudo apt-get update && sudo apt-get -y install gettext-base
+        fi
     - name: run tests
       shell: bash
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.16
-    - id: foo
+    - id: test-runner
       uses: ./.github/actions/tests
       env:
         T: unit
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.16
-    - id: foo
+    - id: test-runner
       uses: ./.github/actions/tests
       env:
         T: integration
@@ -41,7 +41,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.16
-    - id: foo
+    - id: test-runner
       uses: ./.github/actions/tests
       env:
         T: integration
@@ -54,7 +54,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.16
-    - id: foo
+    - id: test-runner
       uses: ./.github/actions/tests
       env:
         T: integration
@@ -68,7 +68,20 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.16
-    - id: foo
+    - id: test-runner
       uses: ./.github/actions/tests
       env:
         T: dry_run_deploy
+  without-envsubst:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+    - id: test-runner
+      uses: ./.github/actions/tests
+      env:
+        T: integration
+        WITHOUT_ENVSUBST: 1

--- a/admission-webhook/run-ci.sh
+++ b/admission-webhook/run-ci.sh
@@ -24,7 +24,8 @@ main() {
 }
 
 run_integration_tests() {
-    if [ "$WITHOUT_ENVSUBST" ] && [ -x "$(command -v envsubst)" ] && [[ "$TRAVIS" == "true" ]]; then
+    if [ "$WITHOUT_ENVSUBST" ] && [ -x "$(command -v envsubst)" ] && [[ "$GITHUB_ACTIONS" == "true" ]]; then
+        echo "Removing envsubst"
         sudo rm -f "$(command -v envsubst)"
     fi
 


### PR DESCRIPTION
As part of #35 I removed the envsubst but it required as part of the end to end tests in testgrid: 

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-1-21-windows-containerd-serial-slow/1398317877165035520: ` FATAL ERROR: Unable to run envsubst`

