### PR TITLE
Adding v1 version for gmsacredentialspec CRDs

### DIFF
--- a/admission-webhook/deploy/gmsa-crd.yml
+++ b/admission-webhook/deploy/gmsa-crd.yml
@@ -31,6 +31,15 @@ spec:
                           type: string
                         Scope:
                           type: string
+                  HostAccountConfig:
+                    type: object
+                    properties:
+                      PluginGUID:
+                        type: string
+                      PluginInput:
+                        type: string
+                      PortableCcgVersion:
+                        type: string
               CmsPlugins:
                 type: array
                 items:

--- a/admission-webhook/deploy/gmsa-crd.yml
+++ b/admission-webhook/deploy/gmsa-crd.yml
@@ -9,6 +9,49 @@ spec:
   versions:
   - name: v1alpha1
     served: true
+    storage: false
+    deprecated: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          credspec:
+            description: GMSA Credential Spec
+            type: object
+            properties:
+              ActiveDirectoryConfig:
+                type: object
+                properties:
+                  GroupManagedServiceAccounts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        Name:
+                          type: string
+                        Scope:
+                          type: string
+              CmsPlugins:
+                type: array
+                items:
+                  type: string
+              DomainJoinConfig:
+                type: object
+                properties:
+                  DnsName:
+                    type: string
+                  DnsTreeName:
+                    type: string
+                  Guid:
+                    type: string
+                  MachineAccountName:
+                    type: string
+                  NetBiosName:
+                    type: string
+                  Sid:
+                    type: string
+  - name: v1
+    served: true
     storage: true
     schema:
       openAPIV3Schema:
@@ -58,6 +101,8 @@ spec:
                     type: string
                   Sid:
                     type: string
+  conversion:
+    strategy: None
   names:
     kind: GMSACredentialSpec
     plural: gmsacredentialspecs

--- a/admission-webhook/integration_tests/kube.go
+++ b/admission-webhook/integration_tests/kube.go
@@ -12,11 +12,13 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func kubeClient(t *testing.T) kubernetes.Interface {
+func clientConfig(t *testing.T) *rest.Config {
 	kubeConfigPath, err := homedir.Expand(kubeconfig())
 	if err != nil {
 		t.Fatal(err)
@@ -26,7 +28,22 @@ func kubeClient(t *testing.T) kubernetes.Interface {
 		t.Fatal(err)
 	}
 
+	return config
+}
+
+func kubeClient(t *testing.T) kubernetes.Interface {
+	config := clientConfig(t)
 	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return client
+}
+
+func dynamicClient(t *testing.T) dynamic.Interface {
+	config := clientConfig(t)
+	client, err := dynamic.NewForConfig(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/admission-webhook/integration_tests/templates/credspec-0.yml
+++ b/admission-webhook/integration_tests/templates/credspec-0.yml
@@ -1,6 +1,6 @@
 # a sample cred spec
 
-apiVersion: windows.k8s.io/v1alpha1
+apiVersion: windows.k8s.io/v1
 kind: GMSACredentialSpec
 metadata:
   name: {{ index .CredSpecNames 0 }}

--- a/admission-webhook/integration_tests/templates/credspec-1.yml
+++ b/admission-webhook/integration_tests/templates/credspec-1.yml
@@ -1,4 +1,7 @@
 # a sample cred spec
+# Note: The apiVersion of this GMSACredentialSpec was intentionally left at windows.k8s.io/v1alpha1
+#   to provide validation for scenarios where users deploy v1alpha CRD objects to their cluster after
+#   updating the CRD definition to use windows.k8s.io/v1 as the storage version.
 
 apiVersion: windows.k8s.io/v1alpha1
 kind: GMSACredentialSpec

--- a/admission-webhook/integration_tests/templates/credspec-2.yml
+++ b/admission-webhook/integration_tests/templates/credspec-2.yml
@@ -1,6 +1,6 @@
 # a sample cred spec
 
-apiVersion: windows.k8s.io/v1alpha1
+apiVersion: windows.k8s.io/v1
 kind: GMSACredentialSpec
 metadata:
   name: {{ index .CredSpecNames 2 }}

--- a/admission-webhook/integration_tests/templates/credspec-with-hostagentconfig.yml
+++ b/admission-webhook/integration_tests/templates/credspec-with-hostagentconfig.yml
@@ -1,6 +1,6 @@
 # a sample cred spec
 
-apiVersion: windows.k8s.io/v1alpha1
+apiVersion: windows.k8s.io/v1
 kind: GMSACredentialSpec
 metadata:
   name: {{ index .CredSpecNames 0 }}

--- a/admission-webhook/kube_client.go
+++ b/admission-webhook/kube_client.go
@@ -18,7 +18,7 @@ import (
 const (
 	// these 3 constants are the coordinates of the Custom Resource Definition
 	crdAPIGroup     = "windows.k8s.io"
-	crdAPIVersion   = "v1alpha1"
+	crdAPIVersion   = "v1"
 	crdResourceName = "gmsacredentialspecs"
 
 	// crdContentsField is the single field that's expected to be defined in a GMSA CRD,

--- a/scripts/GenerateCredentialSpecResource.ps1
+++ b/scripts/GenerateCredentialSpecResource.ps1
@@ -54,7 +54,7 @@ Remove-Item $dockerCredSpecPath
 
 # generate the k8s resource
 $resource = [ordered]@{
-    "apiVersion" = "windows.k8s.io/v1alpha1";
+    "apiVersion" = "windows.k8s.io/v1";
     "kind" = 'GMSACredentialSpec';
     "metadata" = @{
         "name" = $ResourceName


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Fixes #43 

I ran our 'GMSA Full' test on a local cluster and got passing results.
I even saw the deprecation message saying to use the v1 api

```bash
Aug 12 13:40:47.914: INFO: stdout: "apiVersion: windows.k8s.io/v1alpha1\r\nkind: GMSACredentialSpec\r\nmetadata:\r\n  name: gmsa-e2e\r\ncredspec:\r\n  CmsPlugins:\r\n  - ActiveDirectory\r\n  DomainJoinConfig:\r\n    Sid: S-1-5-21-1709982657-1049071122-2546699011\r\n    MachineAccountName: gmsa-e2e\r\n    Guid: d6473599-ce06-46e0-9fa4-ee965441c629\r\n    DnsTreeName: k8sgmsa.lan\r\n    DnsName: k8sgmsa.lan\r\n    NetBiosName: k8sgmsa\r\n  ActiveDirectoryConfig:\r\n    GroupManagedServiceAccounts:\r\n    - Name: gmsa-e2e\r\n      Scope: k8sgmsa.lan\r\n    - Name: gmsa-e2e\r\n      Scope: k8sgmsa\r\n\r\n"

<snip>

Aug 12 13:40:57.120: INFO: stderr: "Warning: windows.k8s.io/v1alpha1 GMSACredentialSpec is deprecated; use windows.k8s.io/v1 GMSACredentialSpec\n"

<snip>

"msg":"PASSED [sig-windows] [Feature:Windows] GMSA Full [Serial] [Slow] GMSA support works end to end","total":1,"completed":1,"skipped":5604,"failed":0}
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
```