### PR TITLE
Adding HostAccountFields to GMSACredentialSpec objects

### DIFF
--- a/admission-webhook/deploy/gmsa-crd.yml
+++ b/admission-webhook/deploy/gmsa-crd.yml
@@ -30,6 +30,15 @@ spec:
                           type: string
                         Scope:
                           type: string
+                  HostAccountConfig:
+                    type: object
+                    properties:
+                      PluginGUID:
+                        type: string
+                      PluginInput:
+                        type: string
+                      PortableCcgVersion:
+                        type: string
               CmsPlugins:
                 type: array
                 items:

--- a/admission-webhook/integration_tests/templates/credspec-with-hostagentconfig.yml
+++ b/admission-webhook/integration_tests/templates/credspec-with-hostagentconfig.yml
@@ -1,0 +1,26 @@
+# a sample cred spec
+
+apiVersion: windows.k8s.io/v1alpha1
+kind: GMSACredentialSpec
+metadata:
+  name: {{ index .CredSpecNames 0 }}
+credspec:
+  ActiveDirectoryConfig:
+    GroupManagedServiceAccounts:
+    - Name: WebApplication2
+      Scope: CONTOSO
+    - Name: WebApplication2
+      Scope: contoso.com
+    HostAccountConfig:
+      PluginGUID: "{GDMA0342-266A-4D1P-831J-20990E82944F}"
+      PluginInput: "contoso.com:gmsaccg:<password>"
+      PortableCcgVersion: "1"
+  CmsPlugins:
+  - ActiveDirectory
+  DomainJoinConfig:
+    DnsName: contoso.com
+    DnsTreeName: contoso.com
+    Guid: 244818ae-87ca-4fcd-92ec-e79e5252348a
+    MachineAccountName: WebApplication2
+    NetBiosName: CONTOSO
+    Sid: S-1-5-21-2126729477-2524275714-3294792973


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Fixes #46 

https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/manage-serviceaccounts#additional-credential-spec-configuration-for-non-domain-joined-container-host-use-case for more info on the new fields