### PR TITLE
Updating makefiles so we can push staging images to gcr.io/k8s-staging/gmsa-webhook

### DIFF
--- a/admission-webhook/Makefile
+++ b/admission-webhook/Makefile
@@ -3,10 +3,13 @@ SHELL := /bin/bash
 
 WEBHOOK_ROOT := $(CURDIR)
 
+REGISTRY?=sigwindowstools
+STAGING_REGISTRY := gcr.io/k8s-staging-gmsa-webhook
+IMAGE_NAME ?= k8s-gmsa-webhook
+TAG :=  $(shell git describe --tags --always `git rev-parse HEAD`)
+WEBHOOK_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
+
 DEV_IMAGE_NAME = k8s-windows-gmsa-webhook-dev
-VERSION = $(shell git describe --tags --always `git rev-parse HEAD`)
-IMAGE_REPO = sigwindowstools/k8s-gmsa-webhook
-IMAGE_NAME = $(IMAGE_REPO):$(VERSION)
 
 CURL = $(shell which curl 2> /dev/null)
 WGET = $(shell which wget 2> /dev/null)
@@ -50,3 +53,7 @@ clean_integration_tests:
 
 .PHONY: clean
 clean: cluster_clean clean_integration_tests deps_clean
+
+.PHONY: release-staging 
+release-staging: ## Builds and push webhook image to k8s-staging bucket
+	REGISTRY=$(STAGING_REGISTRY) $(MAKE) image_build image_push

--- a/admission-webhook/make/dev_cluster.mk
+++ b/admission-webhook/make/dev_cluster.mk
@@ -62,7 +62,7 @@ deploy_dev_webhook:
 # deploys the webhook to the kind cluster with the release image
 .PHONY: deploy_webhook
 deploy_webhook:
-	K8S_GMSA_IMAGE=$(WEBHOOK_IMAGE) $(MAKE) _deploy_webhook
+	K8S_GMSA_IMAGE=$(WEBHOOK_IMG) $(MAKE) _deploy_webhook
 
 # removes the webhook from the kind cluster
 .PHONY: remove_webhook

--- a/admission-webhook/make/dev_cluster.mk
+++ b/admission-webhook/make/dev_cluster.mk
@@ -62,7 +62,7 @@ deploy_dev_webhook:
 # deploys the webhook to the kind cluster with the release image
 .PHONY: deploy_webhook
 deploy_webhook:
-	K8S_GMSA_IMAGE=$(IMAGE_NAME) $(MAKE) _deploy_webhook
+	K8S_GMSA_IMAGE=$(WEBHOOK_IMAGE) $(MAKE) _deploy_webhook
 
 # removes the webhook from the kind cluster
 .PHONY: remove_webhook

--- a/admission-webhook/make/image.mk
+++ b/admission-webhook/make/image.mk
@@ -1,6 +1,6 @@
 # must stay consistent with the go version defined in .travis.yml
 GO_VERSION = 1.17
-DOCKER_BUILD = docker build . --build-arg GO_VERSION=$(GO_VERSION) --build-arg VERSION=$(VERSION)
+DOCKER_BUILD = docker build . --build-arg GO_VERSION=$(GO_VERSION) --build-arg VERSION=$(TAG)
 
 .PHONY: image_build_dev
 image_build_dev:
@@ -8,10 +8,10 @@ image_build_dev:
 
 .PHONY: image_build
 image_build:
-	$(DOCKER_BUILD) -f dockerfiles/Dockerfile -t $(IMAGE_NAME)
-	docker tag $(IMAGE_NAME) $(IMAGE_REPO):latest
+	$(DOCKER_BUILD)  -f dockerfiles/Dockerfile -t $(WEBHOOK_IMG):$(TAG)
+	docker tag $(WEBHOOK_IMG):$(TAG) $(WEBHOOK_IMG):latest
 
 .PHONY: image_push
 image_push:
-	docker push $(IMAGE_NAME)
-	docker push $(IMAGE_REPO):latest
+	docker push $(WEBHOOK_IMG):$(TAG)
+	docker push $(WEBHOOK_IMG):latest

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,24 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 1200s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+    entrypoint: bash
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - TAG=${_GIT_TAG}
+    - PULL_BASE_REF=${_PULL_BASE_REF}
+    args:
+    - cd admission-webhook && make release-staging
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
+  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'master'


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Updating our build files so we can push images to gcr.io/k8s-staging-gmsa-webhook from PROW jobs (which don't exist yet).
I'm adding `make release-staging` which will build and push the images to the staging repository.

Running `make image_build` and `make image_push` will continue to build/push images to `sigwindowstools/k8s-windows-gmsa-webhook`.

