### PR TITLE
Fix to allow for TAG to be inherited from env in the makefiles

### DIFF
--- a/admission-webhook/Makefile
+++ b/admission-webhook/Makefile
@@ -3,10 +3,10 @@ SHELL := /bin/bash
 
 WEBHOOK_ROOT := $(CURDIR)
 
-REGISTRY?=sigwindowstools
-STAGING_REGISTRY := gcr.io/k8s-staging-gmsa-webhook
+REGISTRY ?= sigwindowstools
+STAGING_REGISTRY ?= gcr.io/k8s-staging-gmsa-webhook
 IMAGE_NAME ?= k8s-gmsa-webhook
-TAG :=  $(shell git describe --tags --always `git rev-parse HEAD`)
+TAG ?=  $(shell git describe --tags --always `git rev-parse HEAD`)
 WEBHOOK_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 
 DEV_IMAGE_NAME = k8s-windows-gmsa-webhook-dev

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
     args:
     - -c
     - |
-      echo "Building / Pushing GMSA webhook container image"
+      echo "Building / Pushing GMSA webhook container image with TAG=${TAG}, PULL_BASE_REF=${PULL_BASE_REF}"
       cd admission-webhook
       make release-staging
 substitutions:


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

One more fix to get the cloudbuild job to push images to our staging registry.

Previous jobs failed with

```
docker build . --build-arg GO_VERSION=1.17 --build-arg VERSION= -f dockerfiles/Dockerfile -t gcr.io/k8s-staging-gmsa-webhook/k8s-gmsa-webhook:
invalid argument "gcr.io/k8s-staging-gmsa-webhook/k8s-gmsa-webhook:" for "-t, --tag" flag: invalid reference format
```

/assign @jsturtevant 