### PR TITLE
Updating cloudbuild.yaml again

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
     args:
     - -c
     - |
-      echo "Building / Pushing GMSA webhook container image with TAG=${TAG}, PULL_BASE_REF=${PULL_BASE_REF}"
+      echo "Building / Pushing GMSA webhook container"
       cd admission-webhook
       make release-staging
 substitutions:


### PR DESCRIPTION
trying to fix this error

```
ERROR: (gcloud.builds.submit) INVALID_ARGUMENT: generic::invalid_argument: invalid value for 'build.substitutions': key in the template "TAG" is not a valid built-in substitution

2022/02/17 22:51:14 Failed to run some build jobs: [error running [gcloud builds submit --verbosity info --config /home/prow/go/src/github.com/kubernetes-sigs/windows-gmsa/cloudbuild.yaml --substitutions _PULL_BASE_REF=master,_GIT_TAG=v20220217-v0.3.0-14-gd4a477c --project k8s-staging-gmsa-webhook --gcs-log-dir gs://k8s-staging-gmsa-webhook-gcb/logs --gcs-source-staging-dir gs://k8s-staging-gmsa-webhook-gcb/source gs://k8s-staging-gmsa-webhook-gcb/source/4aea20e2-f729-4ecf-b062-2915819348da.tgz]: &{%!w(*os.ProcessState=&{37 256 0xc0000ec1b0}) []}]
```