### PR TITLE
Tolerate the control-plane taint

### DIFF
--- a/admission-webhook/deploy/deploy-gmsa-webhook.sh
+++ b/admission-webhook/deploy/deploy-gmsa-webhook.sh
@@ -164,6 +164,9 @@ main() {
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
         effect: NoSchedule'
     fi
 


### PR DESCRIPTION
After https://github.com/kubernetes/kubernetes/pull/107533 and https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2098 Clusters my have the taint `node-role.kubernetes.io/control-plane`. This is toleration is needed for the k/k e2e suite where GMSA and this script are used https://github.com/kubernetes/kubernetes/blob/8c1dc25745480b280b38933ed3532e0830f58056/test/e2e/windows/gmsa_full.go#L270