### PR TITLE
Building arm64 admission-webhook image too

### DIFF
--- a/admission-webhook/Makefile
+++ b/admission-webhook/Makefile
@@ -59,4 +59,4 @@ clean: cluster_clean clean_integration_tests deps_clean
 
 .PHONY: release-staging 
 release-staging: ## Builds and push webhook image to k8s-staging bucket
-	REGISTRY=$(STAGING_REGISTRY) $(MAKE) image_build image_push
+	REGISTRY=$(STAGING_REGISTRY) $(MAKE) image_build_and_push

--- a/admission-webhook/dockerfiles/Dockerfile
+++ b/admission-webhook/dockerfiles/Dockerfile
@@ -1,7 +1,10 @@
 ## Dockerfile for release, as lightweight as possible
 
+ARG ARCH
 ARG GO_VERSION
-FROM golang:${GO_VERSION} AS builder
+ARG GOARCH
+
+FROM --platform=linux/amd64 golang:${GO_VERSION} AS builder
 
 WORKDIR /go/src/sigs.k8s.io/windows-gmsa/admission-webhook
 
@@ -13,11 +16,11 @@ COPY go.sum ./go.sum
 COPY *.go ./
 ARG VERSION
 RUN go mod vendor && go mod tidy
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -X main.version=${VERSION}"
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -ldflags="-w -s -X main.version=${VERSION}"
 
 ###
 
-FROM scratch
+FROM --platform=linux/${ARCH} scratch
 
 WORKDIR /admission-webhook
 

--- a/admission-webhook/make/image.mk
+++ b/admission-webhook/make/image.mk
@@ -1,17 +1,40 @@
 # must stay consistent with the go version defined in .travis.yml
 GO_VERSION = 1.20
-DOCKER_BUILD = docker build . --build-arg GO_VERSION=$(GO_VERSION) --build-arg VERSION=$(TAG)
+BUILD_ARGS = --build-arg GO_VERSION=$(GO_VERSION) --build-arg VERSION=$(TAG) 
+DOCKER_BUILD = docker build . $(BUILD_ARGS)
+
+AMD64_ARGS = --build-arg GOARCH=amd64 --build-arg ARCH=amd64 --platform=linux/amd64
+ARM64_ARGS = --build-arg GOARCH=arm64 --build-arg ARCH=arm64 --platform=linux/arm64
+BUILDX_BUILD = docker buildx build . $(BUILD_ARGS) --provenance=false --sbom=false
+
 
 .PHONY: image_build_dev
 image_build_dev:
 	$(DOCKER_BUILD) -f dockerfiles/Dockerfile.dev -t $(DEV_IMAGE_NAME)
 
-.PHONY: image_build
-image_build:
-	$(DOCKER_BUILD)  -f dockerfiles/Dockerfile -t $(WEBHOOK_IMG):$(TAG)
-	docker tag $(WEBHOOK_IMG):$(TAG) $(WEBHOOK_IMG):latest
+.PHONY: create_buildx_builder
+create_buildx_builder:
+	docker buildx create --name img-builder --platform linux/amd64 --use
 
-.PHONY: image_push
-image_push:
-	docker push $(WEBHOOK_IMG):$(TAG)
-	docker push $(WEBHOOK_IMG):latest
+.PHONY: remove_image_builder
+remove_image_builder:
+	docker buildx rm img-builder || true
+
+# Builds an amd64 image and loads it into the local image store - used during integration tests
+image_build: remove_image_builder create_buildx_builder image_build_int remove_image_builder
+
+.PHONY: image_build_int
+image_build_int:
+	$(BUILDX_BUILD) --load $(AMD64_ARGS) -f dockerfiles/Dockerfile -t $(WEBHOOK_IMG):$(TAG) -t $(WEBHOOK_IMG):latest
+
+# Builds and pushes a multi-arch image (amd64 and arm64) to a remote registry
+image_build_and_push: remove_image_builder create_buildx_builder image_build_and_push_int remove_image_builder
+
+.PHONY: image_build_and_push_int
+image_build_and_push_int:
+	$(BUILDX_BUILD) --push $(AMD64_ARGS) -f dockerfiles/Dockerfile -t $(WEBHOOK_IMG):$(TAG)-amd64 -t $(WEBHOOK_IMG):latest-amd64
+	$(BUILDX_BUILD) --push $(ARM64_ARGS) -f dockerfiles/Dockerfile -t $(WEBHOOK_IMG):$(TAG)-arm64 -t $(WEBHOOK_IMG):latest-arm64
+	docker manifest create --amend $(WEBHOOK_IMG):$(TAG) $(WEBHOOK_IMG):$(TAG)-amd64 $(WEBHOOK_IMG):$(TAG)-arm64
+	docker manifest push --purge $(WEBHOOK_IMG):$(TAG)
+	docker manifest create --amend $(WEBHOOK_IMG):latest $(WEBHOOK_IMG):latest-amd64 $(WEBHOOK_IMG):latest-arm64
+	docker manifest push --purge $(WEBHOOK_IMG):latest


### PR DESCRIPTION
Fixes #107 

Updating the build process to build a multi-arch container image with both amd64 and arm64 flavors for the admission-webhook

/hold for CI
/sig windows
/assign @jsturtevant 