### PR TITLE
Updating the cloudbuild image to one that has buildkit 10.x

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name:  'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230111-cd1b3caf9c'
+  - name:  'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230522-312425ae46'
     entrypoint: bash
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
Updating cloudbuild image to one that has buildkit 10.x which honor the `--provenance` flag for docker cli

current image:

```bash
docker run --rm -i -t --entrypoint bash gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230111-cd1b3caf9c
9def5e2820f6:/workspace# docker buildx version
github.com/docker/buildx v0.9.1 ed00243a0ce2a0aee75311b06e32d33b44729689
9def5e2820f6:/workspace# exit
exit
```

target image:

```bash
docker run --rm -i -t --entrypoint bash gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230522-312425ae46
cf918e12966d:/workspace# docker buildx version
github.com/docker/buildx v0.10.4 c513d34049e499c53468deac6c4267ee72948f02
cf918e12966d:/workspace# exit
exit
```