### PR TITLE
call gcloud auth in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,6 +20,7 @@ steps:
     - -c
     - |
       echo "Building / Pushing GMSA webhook container"
+      gcloud auth configure-docker
       cd admission-webhook
       make release-staging
 substitutions:


### PR DESCRIPTION
This should fix the post-build image push job failures
/sig windows
/assign @jsturtevant 

We do this in the windows service proxy builds (and others)
https://github.com/kubernetes-sigs/windows-service-proxy/blob/main/cloudbuild.yaml