### PR TITLE
Infer caBundle from .Values.certificates.secretName

### DIFF
--- a/charts/gmsa/templates/_helpers.tpl
+++ b/charts/gmsa/templates/_helpers.tpl
@@ -26,7 +26,9 @@ apiVersion: cert-manager.io/v1
 {{- end }}
 
 {{- define "certificates.cabundle"}}
-{{- if gt (len (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "")) 0 -}}
+{{- if .Values.certificates.caBundle }}
+{{- .Values.certificates.caBundle }}
+{{- else if gt (len (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "")) 0 -}}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.certificates.secretName) -}}
 {{- if lt (len $secret) 1 -}}
 {{- required (printf "CA Bundle secret '%s' in namespace '%s' must exist" .Values.certificates.secretName .Release.Namespace) "" -}}

--- a/charts/gmsa/templates/mutatingwebhook.yaml
+++ b/charts/gmsa/templates/mutatingwebhook.yaml
@@ -15,7 +15,7 @@ webhooks:
         namespace: {{.Release.Namespace}}
         path: "/mutate"
       {{- if not (.Values.certificates.certManager.enabled) }}
-      caBundle: {{ .Values.certificates.caBundle }}
+      caBundle: {{ template "certificates.cabundle" . }}
       {{- end }}
     rules:
       - operations: ["CREATE"]
@@ -34,4 +34,3 @@ webhooks:
         - key: windows.k8s.io/disabled
           operator: NotIn
           values: ["true"]
-

--- a/charts/gmsa/templates/validatingwebhook.yaml
+++ b/charts/gmsa/templates/validatingwebhook.yaml
@@ -15,7 +15,7 @@ webhooks:
         namespace: {{.Release.Namespace}}
         path: "/validate"
       {{- if not (.Values.certificates.certManager.enabled) }}
-      caBundle: {{ .Values.certificates.caBundle }}
+      caBundle: {{ template "certificates.cabundle" . }}
       {{- end }}
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -34,4 +34,3 @@ webhooks:
         - key: windows.k8s.io/disabled
           operator: NotIn
           values: ["true"]
-


### PR DESCRIPTION
https://github.com/kubernetes-sigs/windows-gmsa/issues/124

Currently, `.Values.certificates.secretName` is no longer supported to provide the `caBundle` that should be supplied to the admission webhooks since the `certificates.cabundle` is no longer queried.

This commit ensures that that functionality is restored for users who are deploying the certificate data as a k8s Secret.

Here are the tests I ran with my changes:

```bash
$ helm template gmsa charts/gmsa | yq e 'select(.kind == "MutatingWebhookConfiguration" or .kind == "ValidatingWebhookConfiguration") | .webhooks[].clientConfig.caBundle'
null
---
null

$ helm template --set 'certificates.certManager.enabled=false' gmsa charts/gmsa | yq e 'select(.kind == "MutatingWebhookConfiguration" or .kind == "ValidatingWebhookConfiguration") | .webhooks[].clientConfig.caBundle'
INSERT_CERTIFICATE_FROM_SECRET
---
INSERT_CERTIFICATE_FROM_SECRET

$ helm template --set 'certificates.certManager.enabled=false' --set 'certificates.caBundle="my-custom-ca-bundle"' gmsa charts/gmsa | yq e 'select(.kind == "MutatingWebhookConfiguration" or .kind == "ValidatingWebhookConfiguration") | .webhooks[].clientConfig.caBundle'

$ helm template --set 'certificates.caBundle="my-custom-ca-bundle"' gmsa charts/gmsa | yq e 'select(.kind == "MutatingWebhookConfiguration" or .kind == "ValidatingWebhookConfiguration") | .webhooks[].clientConfig.caBundle'
null
---
null
```