### PR TITLE
Add credential.hostAccountConfig for CCG scenario

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -42,6 +42,9 @@ The following table lists the configurable parameters of the latest GMSA chart a
 | `credential.domainJoinConfig.machineAccountName`      | username of the GMSA account                                      |                                                       |
 | `credential.domainJoinConfig.netBiosName`             | NETBIOS Domain Name                                               |                                                       |
 | `credential.domainJoinConfig.sid`                     | SID                                                               |                                                       |
+| `credential.hostAccountConfig.pluginGUID`             | GUID of CCG Plugin                                                |                                                       |
+| `credential.hostAccountConfigg.portableCcgVersion`    | Version of CCG Plugin                                             | `1`                                                   |
+| `credential.hostAccountConfig.pluginInput`            | Input to CCG Plugin                                               |                                                       |
 | `image.repository`                                    | image repository                                                  | `registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook`       |
 | `image.tag`                                           | image tag                                                         | `v0.4.0`                                              |
 | `image.imagePullPolicy`                               | image pull policy                                                 | `IfNotPresent`                                        |

--- a/charts/gmsa/templates/credentialspec.yaml
+++ b/charts/gmsa/templates/credentialspec.yaml
@@ -11,11 +11,17 @@ credspec:
         Scope: {{ .Values.credential.domainJoinConfig.netBiosName }} # NETBIOS Domain Name
       - Name: {{ .Values.credential.domainJoinConfig.machineAccountName }} # Username of the GMSA account
         Scope: {{ .Values.credential.domainJoinConfig.dnsName }} # DNS Domain Name
+{{- if .Values.credential.hostAccountConfig }}
+    HostAccountConfig:
+      PortableCcgVersion: {{ required "credential.hostAccountConfig.portableCCGVersion must be provided if credential.hostAccountConfig is set" .Values.credential.hostAccountConfig.portableCcgVersion | quote }} # This needs to equal the current version of CCG which right now is '1'
+      PluginGUID:   {{ printf "{%s}" (required "credential.hostAccountConfig.pluginGUID must be provided if credential.hostAccountConfig is set" .Values.credential.hostAccountConfig.pluginGUID) | quote }} # CCG Plugin GUID
+      PluginInput: {{ required "credential.hostAccountConfig.pluginInput must be provided if credential.hostAccountConfig is set" .Values.credential.hostAccountConfig.pluginInput | quote }} # Format of this field is dependent upon specific CCG Plugin
+{{- end }}
   CmsPlugins:
     - ActiveDirectory
   DomainJoinConfig:
     DnsName: {{ .Values.credential.domainJoinConfig.dnsName }} # DNS Domain Name
-    DnsTreeName:  {{ .Values.credential.domainJoinConfig.dnsName }} # DNS Domain Name Root
+    DnsTreeName:  {{ .Values.credential.domainJoinConfig.dnsTreeName }} # DNS Domain Name Root
     Guid:  {{ .Values.credential.domainJoinConfig.guid }} # GUID of Domain
     MachineAccountName:  {{ .Values.credential.domainJoinConfig.machineAccountName }} # Username of the GMSA account
     NetBiosName:  {{ .Values.credential.domainJoinConfig.netBiosName }} # NETBIOS Domain Name

--- a/charts/gmsa/templates/credentialspec.yaml
+++ b/charts/gmsa/templates/credentialspec.yaml
@@ -7,18 +7,18 @@ metadata:
 credspec:
   ActiveDirectoryConfig:
     GroupManagedServiceAccounts:
-      - Name: {{ .Values.credential.domainJoinConfig.machineAccountName }}   #Username of the GMSA account
-        Scope: {{ .Values.credential.domainJoinConfig.netBiosName }}  #NETBIOS Domain Name
-      - Name: {{ .Values.credential.domainJoinConfig.machineAccountName }}   #Username of the GMSA account
-        Scope: {{ .Values.credential.domainJoinConfig.dnsName }} #DNS Domain Name
+      - Name: {{ .Values.credential.domainJoinConfig.machineAccountName }} # Username of the GMSA account
+        Scope: {{ .Values.credential.domainJoinConfig.netBiosName }} # NETBIOS Domain Name
+      - Name: {{ .Values.credential.domainJoinConfig.machineAccountName }} # Username of the GMSA account
+        Scope: {{ .Values.credential.domainJoinConfig.dnsName }} # DNS Domain Name
   CmsPlugins:
     - ActiveDirectory
   DomainJoinConfig:
-    DnsName: {{ .Values.credential.domainJoinConfig.dnsName }} #DNS Domain Name
-    DnsTreeName:  {{ .Values.credential.domainJoinConfig.dnsName }} #DNS Domain Name Root
-    Guid:  {{ .Values.credential.domainJoinConfig.guid }} #GUID
-    MachineAccountName:  {{ .Values.credential.domainJoinConfig.machineAccountName }} #Username of the GMSA account
-    NetBiosName:  {{ .Values.credential.domainJoinConfig.netBiosName }} #NETBIOS Domain Name
-    Sid:  {{ .Values.credential.domainJoinConfig.sid }} #SID of GMSA
+    DnsName: {{ .Values.credential.domainJoinConfig.dnsName }} # DNS Domain Name
+    DnsTreeName:  {{ .Values.credential.domainJoinConfig.dnsName }} # DNS Domain Name Root
+    Guid:  {{ .Values.credential.domainJoinConfig.guid }} # GUID of Domain
+    MachineAccountName:  {{ .Values.credential.domainJoinConfig.machineAccountName }} # Username of the GMSA account
+    NetBiosName:  {{ .Values.credential.domainJoinConfig.netBiosName }} # NETBIOS Domain Name
+    Sid:  {{ .Values.credential.domainJoinConfig.sid }} # SID of Domain
 {{- end -}}
 

--- a/charts/gmsa/values.yaml
+++ b/charts/gmsa/values.yaml
@@ -10,6 +10,10 @@ certificates:
 
 credential:
   enabled: false
+  hostAccountConfig: {}
+    # pluginGUID: "" # CCG Plugin GUID
+    # portableCcgVersion: "1" # This needs to equal the current version of CCG which right now is '1'
+    # pluginInput: "" # Format of this field is dependent upon specific CCG Plugin
   domainJoinConfig:
     dnsName: "" # DNS Domain Name
     dnsTreeName: "" # DNS Domain Name Root

--- a/charts/gmsa/values.yaml
+++ b/charts/gmsa/values.yaml
@@ -11,12 +11,12 @@ certificates:
 credential:
   enabled: false
   domainJoinConfig:
-    dnsName: ""  #DNS Domain Name
-    dnsTreeName: "" #DNS Domain Name Root
-    guid: ""  #GUID
-    machineAccountName: "" #Username of the GMSA account
-    netBiosName: ""  #NETBIOS Domain Name
-    sid: "" #SID of GMSA
+    dnsName: "" # DNS Domain Name
+    dnsTreeName: "" # DNS Domain Name Root
+    guid: "" # GUID of Domain
+    machineAccountName: "" # Username of the GMSA account
+    netBiosName: "" # NETBIOS Domain Name
+    sid: "" # SID of Domain
 
 containerPort: "443"
 
@@ -25,7 +25,7 @@ image:
   tag: v0.7.0
   imagePullPolicy: IfNotPresent
 
-# if true, will add os fields to pod specs for K8s versions where feature is in beta (v1.24+)
+# If true, will add os fields to pod specs for K8s versions where feature is in beta (v1.24+)
 setPodOs: true
 
 global:


### PR DESCRIPTION
https://github.com/kubernetes-sigs/windows-gmsa/issues/126

This commit adds a new field `.Values.credential.hostAccountConfig` for situations where the default credential deployed by this chart utilizes CCG.

Here are the tests I ran with my changes:

```bash
# No output expected when credential.enabled is false (default)
$ helm template gmsa charts/gmsa | yq e 'select(.kind == "GMSACredentialSpec") | .credspec.ActiveDirectoryConfig.HostAccountConfig'

# Null output expected when credential.enabled is true but hostAccountConfig is not provided
$ helm template --set="credential.enabled=true" gmsa charts/gmsa | yq e 'select(.kind == "GMSACredentialSpec") | .credspec.ActiveDirectoryConfig.HostAccountConfig'
null

# If credential.enabled and hostAccountConfig is not empty, fields must be provided correctly
$ helm template --set="credential.enabled=true" --set="credential.hostAccountConfig.badkey=hi" gmsa charts/gmsa | yq e 'select(.kind == "GMSACredentialSpec") | .credspec.ActiveDirectoryConfig.HostAccountConfig'
Error: execution error at (gmsa/templates/credentialspec.yaml:16:29): credential.hostAccountConfig.portableCCGVersion must be provided if credential.hostAccountConfig is set

Use --debug flag to render out invalid YAML

$ helm template --set="credential.enabled=true" --set="credential.hostAccountConfig.portableCcgVersion=1" --set="credential.hostAccountConfig.pluginGUID=myguid" gmsa charts/gmsa | yq e 'select(.kind == "GMSACredentialSpec") | .credspec.ActiveDirectoryConfig.HostAccountConfig'
Error: execution error at (gmsa/templates/credentialspec.yaml:18:22): credential.hostAccountConfig.pluginInput must be provided if credential.hostAccountConfig is set

Use --debug flag to render out invalid YAML

$ helm template --set="credential.enabled=true" --set="credential.hostAccountConfig.pluginGUID=myguid" --set="credential.hostAccountConfig.pluginInput=myinput" gmsa charts/gmsa | yq e 'select(.kind == "GMSACredentialSpec") | .credspec.ActiveDirectoryConfig.HostAccountConfig' 
Error: execution error at (gmsa/templates/credentialspec.yaml:16:29): credential.hostAccountConfig.portableCCGVersion must be provided if credential.hostAccountConfig is set

Use --debug flag to render out invalid YAML

$ helm template --set="credential.enabled=true" --set="credential.hostAccountConfig.portableCcgVersion=1" --set="credential.hostAccountConfig.pluginInput=myinput" gmsa charts/gmsa | yq e 'select(.kind == "GMSACredentialSpec") | .credspec.ActiveDirectoryConfig.HostAccountConfig' 
Error: execution error at (gmsa/templates/credentialspec.yaml:17:38): credential.hostAccountConfig.pluginGUID must be provided if credential.hostAccountConfig is set

Use --debug flag to render out invalid YAML

# If credential.enabled and hostAccountConfig is properly set, HostAccountConfig is properly set
$ helm template --set="credential.enabled=true" --set="credential.hostAccountConfig.portableCcgVersion=1" --set="credential.hostAccountConfig.pluginGUID=myguid" --set="credential.hostAccountConfig.pluginInput=myinput" gmsa charts/gmsa | yq e 'select(.kind == "GMSACredentialSpec") | .credspec.ActiveDirectoryConfig.HostAccountConfig'
PortableCcgVersion: "1"
PluginGUID: "{myguid}"
PluginInput: "myinput"
```