### PR TITLE
Ensure that securityContext can be set in Helm chart

### DIFF
--- a/charts/gmsa/templates/deployment.yaml
+++ b/charts/gmsa/templates/deployment.yaml
@@ -53,9 +53,9 @@ spec:
               value: /tls/crt
             - name: HTTPS_PORT
               value: "{{ .Values.containerPort }}"
-      {{- if .Values.securityContext }}
-      securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
-      {{- end }}
+          {{- if .Values.securityContext }}
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
       volumes:
         - name: tls
           secret:


### PR DESCRIPTION
https://github.com/kubernetes-sigs/windows-gmsa/issues/131

According to the Kubernetes API reference docs, `podSecurityContext` should correspond to `spec.template.spec.securityContext`.

I'm assuming that the intention of exposing `securityContext` here was to target the `[container]securityContext` of the main container, which should be `spec.template.spec.containers[0].securityContext`.

However, since in the current implementation the `securityContext` and `podSecurityContext` are indented to the same line, one simply overrides the other. So you see this outcome, where the `securityContext` **overrides** the `podSecurityContext` **at a Pod level**:

```bash
$ helm template --set="securityContext.hi=bye" --set="podSecurityContext.hi=windows" gmsa charts/gmsa | yq e 'select(.kind == "Deployment") | {"podSecurityContext": .spec.template.spec.securityContext, "containerSecurityContext": .spec.template.spec.containers[0].securityContext}'
podSecurityContext:
  hi: bye
containerSecurityContext: null
```

To fix this, this commit modifies the indentation to get the correct output. Here is the same command (and a couple of more tests) of the same thing:

```bash
$ helm template gmsa charts/gmsa | yq e 'select(.kind == "Deployment") | {"podSecurityContext": .spec.template.spec.securityContext, "containerSecurityContexts": .spec.template.spec.containers[0].securityContext}'
podSecurityContext: null
containerSecurityContexts: null

$ helm template --set="securityContext.hi=bye" gmsa charts/gmsa | yq e 'select(.kind == "Deployment") | {"podSecurityContext": .spec.template.spec.securityContext, "containerSecurityContext": .spec.template.spec.containers[0].securityContext}'
podSecurityContext: null
containerSecurityContext:
  hi: bye

$ helm template --set="podSecurityContext.hi=windows" gmsa charts/gmsa | yq e 'select(.kind == "Deployment") | {"podSecurityContext": .spec.template.spec.securityContext, "containerSecurityContext": .spec.template.spec.containers[0].securityContext}'
podSecurityContext:
  hi: windows
containerSecurityContext: null

$ helm template --set="securityContext.hi=bye" --set="podSecurityContext.hi=windows" gmsa charts/gmsa | yq e 'select(.kind == "Deployment") | {"podSecurityContext": .spec.template.spec.securityContext, "containerSecurityContext": .spec.template.spec.containers[0].securityContext}'
podSecurityContext:
  hi: windows
containerSecurityContext:
  hi: bye
```