### PR TITLE
Integration tests wasn't running

### DIFF
--- a/admission-webhook/run-ci.sh
+++ b/admission-webhook/run-ci.sh
@@ -91,11 +91,10 @@ run_integration_tests() {
             exit 1
         fi
     else
-        if [[ "$DEPLOY_METHOD" == 'download' ]]; then
-            make integration_tests
-        fi
         if [[ "$DEPLOY_METHOD" == 'chart' ]]; then
             make integration_tests_chart
+        else 
+            make integration_tests
         fi
     fi
 }


### PR DESCRIPTION
After #75 we stopped running the `integration` job since the `DEPLOY_METHOD` isn't set on every job.  Other jobs like `without-envsubst` and `without-envsubst-tolerations` where also not running the tests.