### PR TITLE
Cert rotation for e2e chart

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -113,3 +113,18 @@ jobs:
       env:
         T: integration
         DEPLOY_METHOD: chart
+  integration-rotation-enabled:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.21'
+    - id: test-runner
+      uses: ./.github/actions/tests
+      env:
+        T: integration
+        DEPLOY_METHOD: chart
+        HELM_INSTALL_FLAGS_FLAGS: --set certificates.certReload.enabled=true
+

--- a/admission-webhook/cert_reloader.go
+++ b/admission-webhook/cert_reloader.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"sync"
 
@@ -56,7 +57,7 @@ func (cr *CertReloader) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Ce
 	}
 }
 
-func watchCertFiles(certLoader CertLoader) {
+func watchCertFiles(ctx context.Context, certLoader CertLoader) {
 	logrus.Infof("Starting certificate watcher on path %v and %v", certLoader.CertPath(), certLoader.KeyPath())
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -86,6 +87,9 @@ func watchCertFiles(certLoader CertLoader) {
 					return
 				}
 				logrus.Errorf("watcher error: %v", err)
+			case <-ctx.Done():
+				logrus.Info("stopping certificate watcher")
+				return
 			}
 		}
 	}()

--- a/admission-webhook/integration_tests/integration_test.go
+++ b/admission-webhook/integration_tests/integration_test.go
@@ -440,15 +440,27 @@ func TestPossibleToUpdatePodWithNewCert(t *testing.T) {
 			 *   (using utils like https://github.com/ycheng-kareo/windows-gmsa/blob/watch-reload-cert/admission-webhook/integration_tests/kube.go#L199)
 		**/
 
-		t.Skip("Non chart deployment method not supported")
+		t.Skip("Non chart deployment method not supported for this test")
 	}
 
+	// it takes ~60 seconds for the webhook to pick up the new certificate
+	// so this first run makes sure the old cert still works
 	testName2 := testName + "after-rotation"
 	testConfig2, tearDownFunc2 := integrationTestSetup(t, testName2, credSpecTemplates, templates)
 	defer tearDownFunc2()
 
 	pod2 := waitForPodToComeUp(t, testConfig2.Namespace, "app="+testName2)
 	assert.Equal(t, expectedCredSpec0, extractContainerCredSpecContents(t, pod2, testName2))
+
+	// sleep a bit to ensure the the secret has been propagated to the pod
+	time.Sleep(90 * time.Second)
+
+	testName3 := testName + "after-rotation-propagated"
+	testConfig3, tearDownFunc3 := integrationTestSetup(t, testName3, credSpecTemplates, templates)
+	defer tearDownFunc3()
+
+	pod3 := waitForPodToComeUp(t, testConfig3.Namespace, "app="+testName3)
+	assert.Equal(t, expectedCredSpec0, extractContainerCredSpecContents(t, pod3, testName3))
 }
 
 /* Helpers */

--- a/admission-webhook/integration_tests/integration_test.go
+++ b/admission-webhook/integration_tests/integration_test.go
@@ -443,6 +443,10 @@ func TestPossibleToUpdatePodWithNewCert(t *testing.T) {
 		t.Skip("Non chart deployment method not supported")
 	}
 
+	//give a few mins to settle rotation
+	// TODO why is this needed?!
+	time.Sleep(120 * time.Second)
+
 	testName2 := testName + "after-rotation"
 	testConfig2, tearDownFunc2 := integrationTestSetup(t, testName2, credSpecTemplates, templates)
 	defer tearDownFunc2()

--- a/admission-webhook/integration_tests/integration_test.go
+++ b/admission-webhook/integration_tests/integration_test.go
@@ -443,10 +443,6 @@ func TestPossibleToUpdatePodWithNewCert(t *testing.T) {
 		t.Skip("Non chart deployment method not supported")
 	}
 
-	//give a few mins to settle rotation
-	// TODO why is this needed?!
-	time.Sleep(120 * time.Second)
-
 	testName2 := testName + "after-rotation"
 	testConfig2, tearDownFunc2 := integrationTestSetup(t, testName2, credSpecTemplates, templates)
 	defer tearDownFunc2()

--- a/admission-webhook/make/helm.mk
+++ b/admission-webhook/make/helm.mk
@@ -9,6 +9,10 @@ endif
 install-helm:
 	curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
+.PHONY: install-cmctl
+install-cmctl:
+	go install github.com/cert-manager/cmctl/v2@latest
+
 .PHONY: helm-chart
 helm-chart:
 	$(HELM) package ../charts/gmsa -d ../charts/repo/
@@ -36,8 +40,10 @@ remove_chart:
 # the deploy script as documented in the README, using $K8S_GMSA_DEPLOY_CHART_REPO and
 # $K8S_GMSA_DEPLOY_CHART_VERSION env variables to build the download URL. If VERSION is
 # not set then latest is used.
+# the HELM_INSTALL_FLAGS_FLAGS env var can be set to eg run only specific tests, e.g.:
+# HELM_INSTALL_FLAGS_FLAGS='--set certificates.certReload.enabled=true' make deploy_chart
 .PHONY: _deploy_chart
-_deploy_chart:  _copy_image _deploy_certmanager
+_deploy_chart:  _copy_image _deploy_certmanager install-cmctl
 ifeq ($(K8S_GMSA_CHART),)
 	@ echo "Cannot call target $@ without setting K8S_GMSA_CHART"
 	exit 1

--- a/admission-webhook/webhook.go
+++ b/admission-webhook/webhook.go
@@ -111,7 +111,7 @@ func (webhook *webhook) start(port int, tlsConfig *tlsConfig, listeningChan chan
 				return err
 			}
 
-			go watchCertFiles(certReloader)
+			go watchCertFiles(context.Background(), certReloader)
 
 			webhook.server.TLSConfig = &tls.Config{
 				GetCertificate: certReloader.GetCertificateFunc(),

--- a/admission-webhook/webhook.go
+++ b/admission-webhook/webhook.go
@@ -104,6 +104,7 @@ func (webhook *webhook) start(port int, tlsConfig *tlsConfig, listeningChan chan
 		err = webhook.server.Serve(keepAliveListener)
 	} else {
 		if webhook.config.EnableCertReload {
+			logrus.Infof("Webhook certificate reload enabled")
 			certReloader := NewCertReloader(tlsConfig.crtPath, tlsConfig.keyPath)
 			_, err = certReloader.LoadCertificate()
 			if err != nil {

--- a/charts/gmsa/templates/issuer.yaml
+++ b/charts/gmsa/templates/issuer.yaml
@@ -16,6 +16,7 @@ spec:
   {{- if .Values.certificates.certReload.enabled }}
   privateKey:
     rotationPolicy: Always
+  isCA: true
   {{- end }}
 ---
 {{ template "cert-manager.apiversion" . }}

--- a/charts/gmsa/templates/issuer.yaml
+++ b/charts/gmsa/templates/issuer.yaml
@@ -16,7 +16,6 @@ spec:
   {{- if .Values.certificates.certReload.enabled }}
   privateKey:
     rotationPolicy: Always
-  isCA: true
   {{- end }}
 ---
 {{ template "cert-manager.apiversion" . }}
@@ -26,5 +25,28 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{ include "gmsa.chartref" . | nindent 4 }}
 spec:
+  ca:
+    secretName: {{ .Release.Name }}-root-ca
+---
+{{ template "cert-manager.apiversion" . }}
+kind: ClusterIssuer
+metadata:
+  name: {{ .Release.Name }}-ca
+spec:
   selfSigned: {}
+---
+{{ template "cert-manager.apiversion" . }}
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  isCA: true
+  commonName: {{ .Release.Name }}-ca
+  secretName: {{ .Release.Name }}-root-ca
+  issuerRef:
+    name: {{ .Release.Name }}-ca
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
 {{- end -}}

--- a/charts/gmsa/templates/issuer.yaml
+++ b/charts/gmsa/templates/issuer.yaml
@@ -13,6 +13,10 @@ spec:
     kind: Issuer
     name: {{ .Release.Name }}
   secretName: {{ .Values.certificates.secretName }}
+  {{- if .Values.certificates.certReload.enabled }}
+  privateKey:
+    rotationPolicy: Always
+  {{- end }}
 ---
 {{ template "cert-manager.apiversion" . }}
 kind: Issuer

--- a/charts/gmsa/templates/mutatingwebhook.yaml
+++ b/charts/gmsa/templates/mutatingwebhook.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}
   {{- if .Values.certificates.certManager.enabled }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-ca
   {{- end }}
   labels: {{ include "gmsa.chartref" . | nindent 4 }}
 webhooks:

--- a/charts/gmsa/templates/validatingwebhook.yaml
+++ b/charts/gmsa/templates/validatingwebhook.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}
   {{- if .Values.certificates.certManager.enabled }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-ca
   {{- end }}
   labels: {{ include "gmsa.chartref" . | nindent 4 }}
 webhooks:


### PR DESCRIPTION
Follow up to #141 to add e2e tests

closes #135

This adds e2e tests for cert rotation using Cert-manager.  The general process is the same when using the manual process but I an not going to add those since this tests the functionally of the rotation in the webhook which will be the same no matter how the cert is created/rotated.

This does add root-ca for cert-manager deployment, so that intermediate certs can be signed and issued, while the old one can still be validated.  In a real deployment it would be be advised to use a CA issuer for you PKI infrastructure but this enables us to boot strap it here.  

Read more about this here https://cert-manager.io/docs/configuration/selfsigned/ and here https://cert-manager.io/docs/usage/certificate/#issuance-behavior-rotation-of-the-private-key