### PR TITLE
Fix logic for parsing values

### DIFF
--- a/admission-webhook/main.go
+++ b/admission-webhook/main.go
@@ -89,10 +89,10 @@ func createKubeClient() (*kubeClient, error) {
 
 func env_float(key string, defaultFloat float32) float32 {
 	if v, found := os.LookupEnv(key); found {
-		if i, err := strconv.ParseFloat(v, 32); err != nil {
+		if i, err := strconv.ParseFloat(v, 32); err == nil {
 			return float32(i)
 		}
-		logrus.Warningf("unable to parse environment variable %s; using default value %f", key, defaultFloat)
+		logrus.Warningf("unable to parse environment variable %s with value %s; using default value %f", key, v, defaultFloat)
 	}
 
 	return defaultFloat
@@ -100,10 +100,10 @@ func env_float(key string, defaultFloat float32) float32 {
 
 func env_int(key string, defaultInt int) int {
 	if v, found := os.LookupEnv(key); found {
-		if i, err := strconv.Atoi(v); err != nil {
+		if i, err := strconv.Atoi(v); err == nil {
 			return i
 		}
-		logrus.Warningf("unable to parse environment variable %s; using default value %d", key, defaultInt)
+		logrus.Warningf("unable to parse environment variable %s with value %s; using default value %d", key, v, defaultInt)
 	}
 
 	return defaultInt

--- a/admission-webhook/main_test.go
+++ b/admission-webhook/main_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_env_float(t *testing.T) {
+	defaultFloat := float32(5.0)
+	tests := []struct {
+		name   string
+		envkey string
+		envval string
+		want   float32
+	}{
+		{
+			name:   "Environment variable set to valid float",
+			envkey: "TEST_ENV_FLOAT",
+			envval: "3.14",
+			want:   3.14,
+		},
+		{
+			name:   "Environment variable set to invalid float",
+			envkey: "TEST_ENV_FLOAT",
+			envval: "invalid",
+			want:   float32(defaultFloat),
+		},
+		{
+			name:   "Environment variable not set",
+			envkey: "TEST_ENV_FLOAT",
+			envval: "",
+			want:   float32(defaultFloat),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envval != "" {
+				os.Setenv(tt.envkey, tt.envval)
+			} else {
+				os.Unsetenv(tt.envkey)
+			}
+			if got := env_float(tt.envkey, defaultFloat); got != tt.want {
+				t.Errorf("env_float() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_env_int(t *testing.T) {
+	defaultInt := 5
+	tests := []struct {
+		name   string
+		envkey string
+		envval string
+		want   int
+	}{
+		{
+			name:   "Environment variable set to valid int",
+			envkey: "TEST_ENV_INT",
+			envval: "10",
+			want:   10,
+		},
+		{
+			name:   "Environment variable set to invalid int",
+			envkey: "TEST_ENV_INT",
+			envval: "invalid",
+			want:   defaultInt,
+		},
+		{
+			name:   "Environment variable not set",
+			envkey: "TEST_ENV_INT",
+			envval: "",
+			want:   defaultInt,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envval != "" {
+				os.Setenv(tt.envkey, tt.envval)
+			} else {
+				os.Unsetenv(tt.envkey)
+			}
+			if got := env_int(tt.envkey, defaultInt); got != tt.want {
+				t.Errorf("env_int() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/charts/gmsa/values.yaml
+++ b/charts/gmsa/values.yaml
@@ -49,5 +49,5 @@ podSecurityContext: {}
 replicaCount: 2
 securityContext: {}
 tolerations: []
-qps: 30
+qps: 30.0
 burst: 50


### PR DESCRIPTION
When testing in a local environment I found my logic wasn't correct.  This adds tests to verify the values as well as I ran it locally:

```
k logs windows-gmsa-dev-8d64d4db4-lkm58
time="2024-09-30T18:37:42Z" level=info msg="QPS: 30.000000, Burst: 50"
time="2024-09-30T18:37:42Z" level=info msg="starting webhook server at port 443"
```