### PR TITLE
Include gmsacredentialspecs in aggregate view role

### DIFF
--- a/charts/gmsa/templates/clusterrole.yaml
+++ b/charts/gmsa/templates/clusterrole.yaml
@@ -13,3 +13,16 @@ rules:
   - apiGroups: ["authorization.k8s.io"]
     resources: ["localsubjectaccessreviews"]
     verbs: ["create"]
+---
+# allow visibility of gmsacredentialspecs through built-in "view" role
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-viewer-role
+  labels:
+    {{ include "gmsa.chartref" . }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["windows.k8s.io"]
+    resources: ["gmsacredentialspecs"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Resolve #161 

This is how the helm template looks like
```
# Source: gmsa/templates/clusterrole.yaml
# allow visibility of gmsacredentialspecs through built-in "view" role
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: release-name-viewer-role
  labels:
    chart: gmsa-0.13.0
    rbac.authorization.k8s.io/aggregate-to-view: "true"
rules:
  - apiGroups: ["windows.k8s.io"]
    resources: ["gmsacredentialspecs"]
    verbs: ["get", "list", "watch"]
```