### PR TITLE
start CEL webhook matchConditions

### DIFF
--- a/charts/gmsa/templates/_helpers.tpl
+++ b/charts/gmsa/templates/_helpers.tpl
@@ -45,3 +45,30 @@ apiVersion: cert-manager.io/v1
 INSERT_CERTIFICATE_FROM_SECRET
 {{- end -}}
 {{- end }}
+
+# https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchconditions
+{{- define "webhook.matchConditions" -}}
+matchConditions:
+  - name: 'has-gmsa-credspec'
+    expression: |
+      object.spec.containers.exists(
+        container,
+        has(container.securityContext) &&
+        has(container.securityContext.windowsOptions) &&
+        has(container.securityContext.windowsOptions.gmsaCredentialSpecName) &&
+        size(container.securityContext.windowsOptions.gmsaCredentialSpecName) >= 1
+      )
+{{- end -}}
+
+{{- define "kube.versionMinor" -}}
+{{- $v := .Capabilities.KubeVersion.Version -}}
+{{- if (and .Values.overrideKubeVersion.enabled .Values.overrideKubeVersion.version) -}}
+{{- $v = .Values.overrideKubeVersion.version -}}
+{{- end -}}
+{{- $kubeVersion := $v | replace "v" "" | split "." -}}
+{{- if eq (len $kubeVersion) 3 -}}
+{{- $kubeVersion._1 -}}
+{{- else -}}
+{{- fail (printf "Invalid KubeVersion: %s" $v) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/gmsa/templates/mutatingwebhook.yaml
+++ b/charts/gmsa/templates/mutatingwebhook.yaml
@@ -25,6 +25,9 @@ webhooks:
     failurePolicy: Fail
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
+    {{- if ge ((include "kube.versionMinor" .) | int) 30 }}
+    {{- (include "webhook.matchConditions" .) | nindent 4 }}
+    {{- end }}
     # don't run on ${NAMESPACE}
     namespaceSelector:
       matchExpressions:

--- a/charts/gmsa/templates/validatingwebhook.yaml
+++ b/charts/gmsa/templates/validatingwebhook.yaml
@@ -25,6 +25,9 @@ webhooks:
     failurePolicy: Fail
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
+    {{- if ge ((include "kube.versionMinor" .) | int) 30 }}
+    {{- (include "webhook.matchConditions" .) | nindent 4 }}
+    {{- end }}
     # don't run on ${NAMESPACE}
     namespaceSelector:
       matchExpressions:

--- a/charts/gmsa/values.yaml
+++ b/charts/gmsa/values.yaml
@@ -13,7 +13,8 @@ certificates:
 
 credential:
   enabled: false
-  hostAccountConfig: {}
+  hostAccountConfig:
+    {}
     # pluginGUID: "" # CCG Plugin GUID
     # portableCcgVersion: "1" # This needs to equal the current version of CCG which right now is '1'
     # pluginInput: "" # Format of this field is dependent upon specific CCG Plugin
@@ -56,3 +57,9 @@ tolerations: []
 qps: 30.0
 burst: 50
 randomHostname: false
+
+# override kubernetes server version rather than rely on kubectl / helm Capabilities.KubeVersion.*
+# - sometimes client kubectl might be version skewed from target cluster
+overrideKubeVersion:
+  enabled: true
+  version: v1.29.16

--- a/charts/gmsa/values.yaml
+++ b/charts/gmsa/values.yaml
@@ -61,5 +61,5 @@ randomHostname: false
 # override kubernetes server version rather than rely on kubectl / helm Capabilities.KubeVersion.*
 # - sometimes client kubectl might be version skewed from target cluster
 overrideKubeVersion:
-  enabled: true
+  enabled: false
   version: v1.29.16


### PR DESCRIPTION
fixed this internally a while back in response to https://github.com/kubernetes-sigs/windows-gmsa/issues/148

inserts webhook match conditions such that gmsa doesn't intercept _every_ pod, only those relevant to windows securfity contexts.

extends values to override kubernetes server version. CEL is 1.30+, in my case the client was targeting various clusters thus `Capabilities.KubeVersion` wasn't reliable.