### PR TITLE
Fix: resolve issues with watching and reloading certificate files

### DIFF
--- a/admission-webhook/cert_reloader.go
+++ b/admission-webhook/cert_reloader.go
@@ -1,105 +1,161 @@
 package main
 
 import (
-	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 )
 
-type CertLoader interface {
-	CertPath() string
-	KeyPath() string
-	LoadCertificate() (*tls.Certificate, error)
-}
-
 type CertReloader struct {
-	sync.Mutex
-	certPath    string
-	keyPath     string
+	certPath     string
+	keyPath      string
+	certChecksum [sha256.Size]byte
+	keyChecksum  [sha256.Size]byte
+
 	certificate *tls.Certificate
+	watcher     *fsnotify.Watcher
+	mux         sync.RWMutex
+	stop        chan struct{}
 }
 
-func NewCertReloader(certPath, keyPath string) *CertReloader {
-	return &CertReloader{
-		certPath: certPath,
-		keyPath:  keyPath,
-	}
-}
-
-func (cr *CertReloader) CertPath() string {
-	return cr.certPath
-}
-
-func (cr *CertReloader) KeyPath() string {
-	return cr.keyPath
-}
-
-// LoadCertificate loads or reloads the certificate from disk.
-func (cr *CertReloader) LoadCertificate() (*tls.Certificate, error) {
-	cr.Lock()
-	defer cr.Unlock()
-
-	cert, err := tls.LoadX509KeyPair(cr.certPath, cr.keyPath)
-	if err != nil {
-		return nil, err
-	}
-	cr.certificate = &cert
-	return cr.certificate, nil
-}
-
-// GetCertificateFunc returns a function that can be assigned to tls.Config.GetCertificate
-func (cr *CertReloader) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-	return func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
-		return cr.certificate, nil
-	}
-}
-
-func watchCertFiles(ctx context.Context, certLoader CertLoader) {
-	logrus.Infof("Starting certificate watcher on path %v and %v", certLoader.CertPath(), certLoader.KeyPath())
+func NewCertReloader(certPath, keyPath string) (*CertReloader, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		logrus.Errorf("error creating watcher: %v", err)
+		return nil, fmt.Errorf("failed to create fsnotify watcher: %w", err)
 	}
 
-	go func() {
-		defer watcher.Close()
+	cw := &CertReloader{
+		certPath: certPath,
+		keyPath:  keyPath,
+		watcher:  watcher,
+		stop:     make(chan struct{}),
+	}
 
-		for {
-			select {
-			case event, ok := <-watcher.Events:
-				if !ok {
-					logrus.Errorf("watcher events returned !ok: %v", err)
-					return
-				}
-				logrus.Infof("detected change in certificate file: %v", event.Name)
-				_, err := certLoader.LoadCertificate()
-				if err != nil {
-					logrus.Errorf("error reloading certificate: %v", err)
-				} else {
-					logrus.Infof("successfully reloaded certificate")
-				}
-			case err, ok := <-watcher.Errors:
-				if !ok {
-					logrus.Errorf("watcher error returned !ok: %v", err)
-					return
-				}
-				logrus.Errorf("watcher error: %v", err)
-			case <-ctx.Done():
-				logrus.Info("stopping certificate watcher")
+	// 1. Initial load the certificate from disk.
+	if err := cw.loadCert(); err != nil {
+		_ = watcher.Close()
+		return nil, err
+	}
+
+	// 2. Watch the directory containing the files (When K8s Secret mount updates, it essentially changes the ..data symlink in the parent directory)
+	certDir := filepath.Dir(certPath)
+	if err := watcher.Add(certDir); err != nil {
+		_ = watcher.Close()
+		return nil, fmt.Errorf("failed to watch directory %s: %w", certDir, err)
+	}
+
+	keyDir := filepath.Dir(keyPath)
+	if keyDir != certDir {
+		if err := watcher.Add(keyDir); err != nil {
+			_ = watcher.Close()
+			return nil, fmt.Errorf("failed to watch directory %s: %w", keyDir, err)
+		}
+	}
+
+	logrus.Infof("fsnotify watcher started on directory: %s", certDir)
+	if keyDir != certDir {
+		logrus.Infof("fsnotify watcher started on directory: %s", keyDir)
+	}
+
+	// 3. Start a goroutine to watch for events
+	go cw.watchEvents()
+
+	return cw, nil
+}
+
+func (cw *CertReloader) watchEvents() {
+	var timer *time.Timer
+	var timerCh <-chan time.Time
+	// debounceDuration is the quiet period after the last fsnotify event before
+	// triggering a reload. fsnotify commonly emits multiple events for a single
+	// file operation (e.g., WRITE + CHMOD). Debouncing coalesces these into
+	// one reload
+	debounceDuration := 200 * time.Millisecond
+
+	for {
+		select {
+		case <-cw.stop:
+			if timer != nil {
+				timer.Stop()
+			}
+			return
+		case event, ok := <-cw.watcher.Events:
+			if !ok {
 				return
 			}
+			// K8s Secret updates trigger Write/Create/Chmod or Remove events
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Chmod) || event.Has(fsnotify.Remove) {
+				// Use a synchronous debounce mechanism to avoid concurrent loadCert calls and frequent reads
+				if timer != nil {
+					timer.Stop()
+				}
+				timer = time.NewTimer(debounceDuration)
+				timerCh = timer.C
+			}
+		case <-timerCh:
+			if err := cw.loadCert(); err != nil {
+				logrus.Errorf("Event-driven cert reload failed: %v", err)
+			}
+		case err, ok := <-cw.watcher.Errors:
+			if !ok {
+				return
+			}
+			logrus.Errorf("fsnotify error: %v", err)
 		}
-	}()
+	}
+}
 
-	err = watcher.Add(certLoader.CertPath())
-	if err != nil {
-		logrus.Fatalf("error watching certificate file: %v", err)
+func (cw *CertReloader) Stop() {
+	close(cw.stop)
+	_ = cw.watcher.Close()
+}
+
+func (cw *CertReloader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	cw.mux.RLock()
+	defer cw.mux.RUnlock()
+	if cw.certificate == nil {
+		return nil, os.ErrNotExist
 	}
-	err = watcher.Add(certLoader.KeyPath())
+	return cw.certificate, nil
+}
+
+func (cw *CertReloader) loadCert() error {
+	certFile, err := os.ReadFile(cw.certPath)
 	if err != nil {
-		logrus.Fatalf("error watching key file: %v", err)
+		return fmt.Errorf("read cert failed: %w", err)
 	}
+	keyFile, err := os.ReadFile(cw.keyPath)
+	if err != nil {
+		return fmt.Errorf("read key failed: %w", err)
+	}
+
+	certChecksum := sha256.Sum256(certFile)
+	keyChecksum := sha256.Sum256(keyFile)
+
+	cw.mux.RLock()
+	same := certChecksum == cw.certChecksum && keyChecksum == cw.keyChecksum
+	cw.mux.RUnlock()
+
+	if !same {
+		keyPair, err := tls.X509KeyPair(certFile, keyFile)
+		if err != nil {
+			return fmt.Errorf("parse key pair failed: %w", err)
+		}
+
+		cw.mux.Lock()
+		cw.certificate = &keyPair
+		cw.certChecksum = certChecksum
+		cw.keyChecksum = keyChecksum
+		cw.mux.Unlock()
+
+		logrus.Info("[fsnotify] Certificate dynamically reloaded into memory in real-time!")
+	}
+	return nil
 }

--- a/admission-webhook/cert_reloader_test.go
+++ b/admission-webhook/cert_reloader_test.go
@@ -1,117 +1,102 @@
 package main
 
 import (
-	"context"
-	"crypto/tls"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// TestCertReloader tests the reloading functionality of the certificate.
-func TestCertReloader(t *testing.T) {
-	// Create temporary cert and key files
-	tmpCertFile, err := os.CreateTemp("", "cert*.pem")
+// generateTestCert generates a self-signed certificate and key for testing
+func generateTestCert(certPath, keyPath string) error {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		t.Fatalf("Failed to create temp cert file: %v", err)
-	}
-	defer os.Remove(tmpCertFile.Name()) // clean up
-
-	tmpKeyFile, err := os.CreateTemp("", "key*.pem")
-	if err != nil {
-		t.Fatalf("Failed to create temp key file: %v", err)
-	}
-	defer os.Remove(tmpKeyFile.Name()) // clean up
-
-	// Write initial cert and key to temp files
-	initialCertData, _ := os.ReadFile("testdata/cert.pem")
-	if err := os.WriteFile(tmpCertFile.Name(), initialCertData, 0644); err != nil {
-		t.Fatalf("Failed to write to temp cert file: %v", err)
+		return err
 	}
 
-	initialKeyData, _ := os.ReadFile("testdata/key.pem")
-	if err := os.WriteFile(tmpKeyFile.Name(), initialKeyData, 0644); err != nil {
-		t.Fatalf("Failed to write to temp key file: %v", err)
-	}
-
-	// Setup CertReloader with temp files
-	certReloader := NewCertReloader(tmpCertFile.Name(), tmpKeyFile.Name())
-	_, err = certReloader.LoadCertificate()
-	if err != nil {
-		t.Fatalf("Failed to load initial certificate: %v", err)
-	}
-
-	// Mocking a certificate change by writing new data to the files
-	newCertData, _ := os.ReadFile("testdata/cert.pem")
-	if err := os.WriteFile(tmpCertFile.Name(), newCertData, 0644); err != nil {
-		t.Fatalf("Failed to write new data to cert file: %v", err)
-	}
-
-	// Simulate reloading
-	_, err = certReloader.LoadCertificate()
-	if err != nil {
-		t.Fatalf("Failed to reload certificate: %v", err)
-	}
-}
-
-type mockCertLoader struct {
-	certPath     string
-	keyPath      string
-	loadCertFunc func() (*tls.Certificate, error)
-}
-
-func (m *mockCertLoader) CertPath() string {
-	return m.certPath
-}
-
-func (m *mockCertLoader) KeyPath() string {
-	return m.keyPath
-}
-
-func (m *mockCertLoader) LoadCertificate() (*tls.Certificate, error) {
-	return m.loadCertFunc()
-}
-
-func TestWatchingCertFiles(t *testing.T) {
-	tmpCertFile, err := os.CreateTemp("", "cert*.pem")
-	if err != nil {
-		t.Fatalf("Failed to create temp cert file: %v", err)
-	}
-	defer os.Remove(tmpCertFile.Name())
-
-	tmpKeyFile, err := os.CreateTemp("", "key*.pem")
-	if err != nil {
-		t.Fatalf("Failed to create temp key file: %v", err)
-	}
-	defer os.Remove(tmpKeyFile.Name())
-
-	loadCertFuncChan := make(chan bool)
-	done := make(chan bool)
-
-	cl := &mockCertLoader{
-		certPath: tmpCertFile.Name(),
-		keyPath:  tmpKeyFile.Name(),
-		loadCertFunc: func() (*tls.Certificate, error) {
-			loadCertFuncChan <- true
-			return &tls.Certificate{}, nil
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Corp"},
 		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour * 24),
 	}
 
-	go func() {
-		called := <-loadCertFuncChan
-		assert.True(t, called)
-		done <- true
-	}()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	watchCertFiles(ctx, cl)
-
-	newCertData, _ := os.ReadFile("testdata/cert.pem")
-	if err := os.WriteFile(tmpCertFile.Name(), newCertData, 0644); err != nil {
-		t.Fatalf("Failed to write new data to cert file: %v", err)
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return err
 	}
 
-	<-done
+	certOut, err := os.Create(certPath)
+	if err != nil {
+		return err
+	}
+	defer certOut.Close()
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		return err
+	}
+
+	keyOut, err := os.Create(keyPath)
+	if err != nil {
+		return err
+	}
+	defer keyOut.Close()
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return err
+	}
+	if err := pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestCertReloader(t *testing.T) {
+	// 1. Create a temporary directory for certs
+	tmpDir, err := os.MkdirTemp("", "cert-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	certPath := filepath.Join(tmpDir, "tls.crt")
+	keyPath := filepath.Join(tmpDir, "tls.key")
+
+	// 2. Generate initial certificates
+	err = generateTestCert(certPath, keyPath)
+	require.NoError(t, err)
+
+	// 3. Initialize the EventCertWatcher
+	watcher, err := NewCertReloader(certPath, keyPath)
+	require.NoError(t, err)
+	defer watcher.Stop()
+
+	// 4. Verify initial certificate is loaded
+	cert1, err := watcher.GetCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert1)
+
+	// 5. Generate new certificates to simulate a K8s Secret update
+	err = generateTestCert(certPath, keyPath)
+	require.NoError(t, err)
+
+	// 6. Wait for fsnotify to pick up the change and the 100ms debounce to fire
+	time.Sleep(300 * time.Millisecond)
+
+	// 7. Verify the certificate was reloaded
+	cert2, err := watcher.GetCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert2)
+
+	// The pointers should be different, meaning a new cert was loaded
+	assert.NotSame(t, cert1, cert2)
 }

--- a/admission-webhook/webhook.go
+++ b/admission-webhook/webhook.go
@@ -114,16 +114,15 @@ func (webhook *webhook) start(port int, tlsConfig *tlsConfig, listeningChan chan
 	} else {
 		if webhook.config.EnableCertReload {
 			logrus.Infof("Webhook certificate reload enabled")
-			certReloader := NewCertReloader(tlsConfig.crtPath, tlsConfig.keyPath)
-			_, err = certReloader.LoadCertificate()
+			certWatcher, err := NewCertReloader(tlsConfig.crtPath, tlsConfig.keyPath)
 			if err != nil {
 				return err
 			}
-
-			go watchCertFiles(context.Background(), certReloader)
+			// Note: certWatcher.Stop() is not explicitly deferred here because ServeTLS is blocking
+			// and the process typically exits when it returns.
 
 			webhook.server.TLSConfig = &tls.Config{
-				GetCertificate: certReloader.GetCertificateFunc(),
+				GetCertificate: certWatcher.GetCertificate,
 			}
 
 			err = webhook.server.ServeTLS(keepAliveListener, "", "")


### PR DESCRIPTION
# Description
This PR addresses the issue reported in #176 regarding incorrect certificate files watching and reloading. cc @Christian-8


# Root Cause
The previous implementation of the --cert-reload=true feature relied on fsnotify to watch the specific certificate files (tls.crt and tls.key). However, Kubernetes mounts Secrets  using symbolic links (e.g., ..data). When a Secret is updated, the Kubelet creates a new timestamped directory, updates the symlink, and removes the old directory.

Because the old code watched the file directly, it received a remove event during the symlink rotation. This caused the underlying fsnotify watcher to permanently die (silently fail). Consequently, the webhook process became "deaf" to any subsequent certificate updates, continued serving the stale certificate from memory, and eventually caused API Server TLS handshake failures once the old certificate expired or the trust chain was strictly enforced.

# Solution
This PR refactors the CertReloader to make it production-ready and fully compatible with Kubernetes Secret mounts:

- Watch the Parent Directory: Instead of watching the symlinked files directly, the watcher now monitors the parent directory (filepath.Dir(certPath)). This ensures the watcher survives Kubelet's atomic symlink replacements.

- Synchronous Debounce Mechanism: Kubelet's symlink rotation generates a burst of filesystem events (create,chmod, remove). A 200ms trailing-edge debounce timer has been introduced to coalesce these rapid-fire events into a single, safe loadCert call, preventing redundant reads and potential race conditions during the intermediate state.

- Thread-Safe Memory Updates: Introduced sync.RWMutex to ensure that updating the certificate in memory (Lock) and serving it to the HTTPS server (RLock in GetCertificate) is strictly thread-safe, eliminating potential data races that could panic the webhook.

- Performance Optimization via Checksum: Added SHA256 checksum validation. The expensive tls.X509KeyPair parsing and write-lock are only triggered if the actual contents of the certificate or key have changed.

# Test Done
- Unit Tests: Completely rewrote cert_reloader_test.go to dynamically generate RSA certificates, simulate file overwrites, and assert that the hot-reload logic works correctly within the debounce window.
```
make test      
go mod vendor
go test -v -count=1 -cover 
=== RUN   TestCertReloader
INFO[0000] [fsnotify] Certificate dynamically reloaded into memory in real-time! 
INFO[0000] fsnotify watcher started on directory: /var/folders/z7/wn00mqdj5yg2btvhrlj0ch640000gq/T/cert-test-15022979 
INFO[0000] [fsnotify] Certificate dynamically reloaded into memory in real-time! 
--- PASS: TestCertReloader (0.55s)
...........
    --- PASS: TestEqualStringPointers/with_s1__=_bar_and_s2__=_foo,_should_return_false (0.00s)
PASS
coverage: 67.4% of statements
ok      github.com/kubernetes-sigs/windows-gmsa/admission-webhook       2.803s
```

- E2E Testing: Deployed the patched webhook with cert-reload=true to a live Kubernetes cluster.

   - Performed rapid, continuous deletions of the gmsa-server-cert Secret. The webhook remained responsive without any downtime or panic.
   - Forced a strict trust-chain rotation by deleting both the Root CA and the Leaf certificate, then patched the MutatingWebhookConfiguration to only trust the newly generated CA. The webhook successfully hot-reloaded the new certificate and admitted pods without throwing the x509 error, proving the watcher remained alive and functional.

```
time="2026-07-28T05:52:22Z" level=info msg="[fsnotify] Certificate dynamically reloaded into memory in real-time!"
time="2026-07-28T05:53:44Z" level=info msg="[fsnotify] Certificate dynamically reloaded into memory in real-time!"
```

# Related Issues
  - Fixes #176