### PR TITLE
webhook: apply GMSA cred spec authorization and mutation to init containers

### DIFF
--- a/admission-webhook/utils_test.go
+++ b/admission-webhook/utils_test.go
@@ -73,21 +73,19 @@ func buildPod(serviceAccountName string, podWindowsOptions *corev1.WindowsSecuri
 // case a `*corev1.WindowsSecurityContextOptions` is built using that string as the name of the cred spec to use.
 // Same goes for the values of `containerNamesAndWindowsOptions`.
 func buildPodWithHostName(serviceAccountName string, hostname *string, podWindowsOptions *corev1.WindowsSecurityContextOptions, containerNamesAndWindowsOptions map[string]*corev1.WindowsSecurityContextOptions) *corev1.Pod {
-	containers := make([]corev1.Container, len(containerNamesAndWindowsOptions))
-	i := 0
-	for name, winOptions := range containerNamesAndWindowsOptions {
-		containers[i] = corev1.Container{Name: name}
-		if winOptions != nil {
-			containers[i].SecurityContext = &corev1.SecurityContext{WindowsOptions: winOptions}
-		}
-		i++
-	}
+	return buildPodWithInitContainers(serviceAccountName, hostname, podWindowsOptions, containerNamesAndWindowsOptions, nil)
+}
 
-	shuffleContainers(containers)
+// buildPodWithInitContainers is like buildPodWithHostName, but also populates `.Spec.InitContainers`
+// from `initContainerNamesAndWindowsOptions`, using the same conventions as `containerNamesAndWindowsOptions`.
+func buildPodWithInitContainers(serviceAccountName string, hostname *string, podWindowsOptions *corev1.WindowsSecurityContextOptions, containerNamesAndWindowsOptions, initContainerNamesAndWindowsOptions map[string]*corev1.WindowsSecurityContextOptions) *corev1.Pod {
+	containers := buildContainers(containerNamesAndWindowsOptions)
+	initContainers := buildContainers(initContainerNamesAndWindowsOptions)
 
 	podSpec := corev1.PodSpec{
 		ServiceAccountName: serviceAccountName,
 		Containers:         containers,
+		InitContainers:     initContainers,
 	}
 
 	if hostname != nil {
@@ -102,6 +100,25 @@ func buildPodWithHostName(serviceAccountName string, hostname *string, podWindow
 		ObjectMeta: metav1.ObjectMeta{Name: dummyPodName},
 		Spec:       podSpec,
 	}
+}
+
+// buildContainers builds a shuffled slice of containers named after the keys of
+// `namesAndWindowsOptions`, with their `.SecurityContext.WindowsOptions` field set to the
+// corresponding value.
+func buildContainers(namesAndWindowsOptions map[string]*corev1.WindowsSecurityContextOptions) []corev1.Container {
+	containers := make([]corev1.Container, len(namesAndWindowsOptions))
+	i := 0
+	for name, winOptions := range namesAndWindowsOptions {
+		containers[i] = corev1.Container{Name: name}
+		if winOptions != nil {
+			containers[i].SecurityContext = &corev1.SecurityContext{WindowsOptions: winOptions}
+		}
+		i++
+	}
+
+	shuffleContainers(containers)
+
+	return containers
 }
 
 func shuffleContainers(a []corev1.Container) {

--- a/admission-webhook/webhook.go
+++ b/admission-webhook/webhook.go
@@ -33,8 +33,9 @@ const (
 	validate webhookOperation = "VALIDATE"
 	mutate   webhookOperation = "MUTATE"
 
-	podKind       gmsaResourceKind = "pod"
-	containerKind gmsaResourceKind = "container"
+	podKind           gmsaResourceKind = "pod"
+	containerKind     gmsaResourceKind = "container"
+	initContainerKind gmsaResourceKind = "initContainer"
 )
 
 type webhook struct {

--- a/admission-webhook/webhook.go
+++ b/admission-webhook/webhook.go
@@ -447,12 +447,12 @@ func validateUpdateRequest(pod, oldPod *corev1.Pod) (*admissionV1.AdmissionRespo
 				oldWindowsOptions = oldPod.Spec.SecurityContext.WindowsOptions
 			}
 		} else {
-			// it's a container; look for the same container in the old pod,
+			// it's a container or an init container; look for the same container in the old pod,
 			// lazily building the map of container names to security options if needed
 			if oldPodContainerOptions == nil {
 				oldPodContainerOptions = make(map[string]*corev1.WindowsSecurityContextOptions)
 				iterateOverWindowsSecurityOptions(oldPod, func(winOpts *corev1.WindowsSecurityContextOptions, rsrcKind gmsaResourceKind, rsrcName string, _ int) *podAdmissionError {
-					if rsrcKind == containerKind {
+					if rsrcKind != podKind {
 						oldPodContainerOptions[rsrcName] = winOpts
 					}
 					return nil

--- a/admission-webhook/webhook.go
+++ b/admission-webhook/webhook.go
@@ -495,10 +495,11 @@ func equalStringPointers(s1, s2 *string) bool {
 }
 
 // iterateOverWindowsSecurityOptions calls `f` on the pod's `.Spec.SecurityContext.WindowsOptions` field,
-// as well as over each of its container's `.SecurityContext.WindowsOptions` field.
+// as well as over each of its containers' and init containers' `.SecurityContext.WindowsOptions` field.
 // `f` can assume it only gets called with non-nil `WindowsSecurityOptions` pointers; the other
 // arguments give information on the resource owning that pointer - in particular, if that
-// resource is a container, `containerIndex` is the index of the container in the spec's list (-1 for pods).
+// resource is a container or an init container, `containerIndex` is the index of the container in the
+// spec's relevant list (`.Spec.Containers` or `.Spec.InitContainers`, respectively; -1 for pods).
 // If `f` returns an error, that breaks the loop, and the error is bubbled up.
 func iterateOverWindowsSecurityOptions(pod *corev1.Pod, f func(windowsOptions *corev1.WindowsSecurityContextOptions, resourceKind gmsaResourceKind, resourceName string, containerIndex int) *podAdmissionError) *podAdmissionError {
 	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.WindowsOptions != nil {
@@ -510,6 +511,14 @@ func iterateOverWindowsSecurityOptions(pod *corev1.Pod, f func(windowsOptions *c
 	for i, container := range pod.Spec.Containers {
 		if container.SecurityContext != nil && container.SecurityContext.WindowsOptions != nil {
 			if err := f(container.SecurityContext.WindowsOptions, containerKind, container.Name, i); err != nil {
+				return err
+			}
+		}
+	}
+
+	for i, container := range pod.Spec.InitContainers {
+		if container.SecurityContext != nil && container.SecurityContext.WindowsOptions != nil {
+			if err := f(container.SecurityContext.WindowsOptions, initContainerKind, container.Name, i); err != nil {
 				return err
 			}
 		}

--- a/admission-webhook/webhook.go
+++ b/admission-webhook/webhook.go
@@ -382,8 +382,11 @@ func (webhook *webhook) mutateCreateRequest(ctx context.Context, pod *corev1.Pod
 				}
 
 				partialPath := ""
-				if resourceKind == containerKind {
+				switch resourceKind {
+				case containerKind:
 					partialPath = fmt.Sprintf("/containers/%d", containerIndex)
+				case initContainerKind:
+					partialPath = fmt.Sprintf("/initContainers/%d", containerIndex)
 				}
 
 				// worth noting that this JSON patch is guaranteed to work since we know at this point

--- a/admission-webhook/webhook_test.go
+++ b/admission-webhook/webhook_test.go
@@ -310,7 +310,8 @@ func TestMutateCreateRequest(t *testing.T) {
 			patchPath := func(kind gmsaResourceKind, name string) string {
 				partialPath := ""
 
-				if kind == containerKind {
+				switch kind {
+				case containerKind:
 					containerIndex := -1
 					for i, container := range pod.Spec.Containers {
 						if container.Name == name {
@@ -323,6 +324,19 @@ func TestMutateCreateRequest(t *testing.T) {
 					}
 
 					partialPath = fmt.Sprintf("/containers/%d", containerIndex)
+				case initContainerKind:
+					containerIndex := -1
+					for i, container := range pod.Spec.InitContainers {
+						if container.Name == name {
+							containerIndex = i
+							break
+						}
+					}
+					if containerIndex == -1 {
+						t.Fatalf("Did not find any init container named %q", name)
+					}
+
+					partialPath = fmt.Sprintf("/initContainers/%d", containerIndex)
 				}
 
 				return fmt.Sprintf("/spec%s/securityContext/windowsOptions/gmsaCredentialSpec", partialPath)
@@ -330,7 +344,7 @@ func TestMutateCreateRequest(t *testing.T) {
 
 			// maps the contents to the expected patch for that container
 			expectedPatches := make(map[string]map[string]string)
-			for i := 0; i < len(pod.Spec.Containers)-1; i++ {
+			for i := 0; i < numExtraRegularContainers(pod, resourceKind); i++ {
 				credSpecContents := extraContainerName(i) + "-cred-spec-contents"
 				expectedPatches[credSpecContents] = map[string]string{
 					"op":    "add",
@@ -346,8 +360,9 @@ func TestMutateCreateRequest(t *testing.T) {
 			}
 
 			var patches []map[string]string
-			// len(pod.Spec.Containers)+1 because we're adding the hostname
-			if err := json.Unmarshal(response.Patch, &patches); assert.Nil(t, err) && assert.Equal(t, len(pod.Spec.Containers)+1, len(patches)) {
+			// numExtraRegularContainers(pod, resourceKind)+2 because the resource under test also gets a
+			// patch, and we're adding the hostname
+			if err := json.Unmarshal(response.Patch, &patches); assert.Nil(t, err) && assert.Equal(t, numExtraRegularContainers(pod, resourceKind)+2, len(patches)) {
 				foundHostname := false
 				for _, patch := range patches {
 					if value, hasValue := patch["value"]; assert.True(t, hasValue) {
@@ -365,7 +380,7 @@ func TestMutateCreateRequest(t *testing.T) {
 		},
 
 		// random hostname env not set in the following cases, and validated no hostname is set (implicitly)
-		"it the cred spec's contents are already set, along with its name, it passes and doesn't overwrite the provided contents": func(t *testing.T, pod *corev1.Pod, optionsSelector winOptionsSelector, _ gmsaResourceKind, _ string) {
+		"it the cred spec's contents are already set, along with its name, it passes and doesn't overwrite the provided contents": func(t *testing.T, pod *corev1.Pod, optionsSelector winOptionsSelector, resourceKind gmsaResourceKind, _ string) {
 			webhook := newWebhook(kubeClientFactory())
 
 			setWindowsOptions(optionsSelector(pod), dummyCredSpecName, `{"pre-set GMSA": "cred contents"}`)
@@ -374,7 +389,7 @@ func TestMutateCreateRequest(t *testing.T) {
 			assert.Nil(t, err)
 
 			// all the patches we receive should be for the extra containers
-			expectedPatchesLen := len(pod.Spec.Containers) - 1
+			expectedPatchesLen := numExtraRegularContainers(pod, resourceKind)
 
 			if expectedPatchesLen == 0 {
 				assert.Nil(t, response.PatchType)
@@ -672,6 +687,19 @@ func runWebhookValidateOrMutateTests(t *testing.T, winOptionsFactory containerWi
 
 func extraContainerName(i int) string {
 	return fmt.Sprintf("extra-container-%d", i)
+}
+
+// numExtraRegularContainers returns the number of "extra" (i.e. not under test) regular
+// containers set on pod.Spec.Containers. runWebhookValidateOrMutateTests always mixes the
+// container under test into pod.Spec.Containers for podKind/containerKind, but keeps
+// pod.Spec.Containers to only the extra containers for initContainerKind (the container under
+// test lives in pod.Spec.InitContainers instead).
+func numExtraRegularContainers(pod *corev1.Pod, resourceKind gmsaResourceKind) int {
+	count := len(pod.Spec.Containers)
+	if resourceKind != initContainerKind {
+		count--
+	}
+	return count
 }
 
 func assertPodAdmissionErrorContains(t *testing.T, err *podAdmissionError, pod *corev1.Pod, httpCode int, msgFormat string, msgArgs ...interface{}) bool {

--- a/admission-webhook/webhook_test.go
+++ b/admission-webhook/webhook_test.go
@@ -597,16 +597,18 @@ func runWebhookValidateOrMutateTests(t *testing.T, winOptionsFactory containerWi
 			testNameSuffix = fmt.Sprintf(" and %d extra containers", extraContainersCount)
 		}
 
-		for _, resourceKind := range []gmsaResourceKind{podKind, containerKind} {
+		for _, resourceKind := range []gmsaResourceKind{podKind, containerKind, initContainerKind} {
 			for testName, testFunc := range tests {
 				podWindowsOptions := &corev1.WindowsSecurityContextOptions{}
-				containerNamesAndWindowsOptions[dummyContainerName] = &corev1.WindowsSecurityContextOptions{}
-				pod := buildPod(dummyServiceAccoutName, podWindowsOptions, containerNamesAndWindowsOptions)
 
+				var pod *corev1.Pod
 				var optionsSelector winOptionsSelector
 				var resourceName string
 				switch resourceKind {
 				case podKind:
+					containerNamesAndWindowsOptions[dummyContainerName] = &corev1.WindowsSecurityContextOptions{}
+					pod = buildPod(dummyServiceAccoutName, podWindowsOptions, containerNamesAndWindowsOptions)
+
 					optionsSelector = func(pod *corev1.Pod) *corev1.WindowsSecurityContextOptions {
 						if pod != nil && pod.Spec.SecurityContext != nil {
 							return pod.Spec.SecurityContext.WindowsOptions
@@ -616,9 +618,34 @@ func runWebhookValidateOrMutateTests(t *testing.T, winOptionsFactory containerWi
 
 					resourceName = dummyPodName
 				case containerKind:
+					containerNamesAndWindowsOptions[dummyContainerName] = &corev1.WindowsSecurityContextOptions{}
+					pod = buildPod(dummyServiceAccoutName, podWindowsOptions, containerNamesAndWindowsOptions)
+
 					optionsSelector = func(pod *corev1.Pod) *corev1.WindowsSecurityContextOptions {
 						if pod != nil {
 							for _, container := range pod.Spec.Containers {
+								if container.Name == dummyContainerName {
+									if container.SecurityContext != nil {
+										return container.SecurityContext.WindowsOptions
+									}
+									return nil
+								}
+							}
+						}
+						return nil
+					}
+
+					resourceName = dummyContainerName
+				case initContainerKind:
+					// the dummy container under test is an init container here, so it must not also
+					// be present amongst the (regular) extra containers.
+					delete(containerNamesAndWindowsOptions, dummyContainerName)
+					initContainerNamesAndWindowsOptions := map[string]*corev1.WindowsSecurityContextOptions{dummyContainerName: {}}
+					pod = buildPodWithInitContainers(dummyServiceAccoutName, nil, podWindowsOptions, containerNamesAndWindowsOptions, initContainerNamesAndWindowsOptions)
+
+					optionsSelector = func(pod *corev1.Pod) *corev1.WindowsSecurityContextOptions {
+						if pod != nil {
+							for _, container := range pod.Spec.InitContainers {
 								if container.Name == dummyContainerName {
 									if container.SecurityContext != nil {
 										return container.SecurityContext.WindowsOptions


### PR DESCRIPTION
## What this PR does

The admission webhook's shared iteration helper, `iterateOverWindowsSecurityOptions`, visits the pod-level `WindowsSecurityContextOptions` and each regular container's, but did not visit init containers. Since the `use`-permission authorization check, the inline `CredentialSpec` content comparison, and the mutating webhook's inlining logic are all built on top of this iterator, none of them were being applied consistently to init containers.

This PR:
- Extends `iterateOverWindowsSecurityOptions` to also visit `pod.Spec.InitContainers`.
- Fixes the mutating webhook's generated JSON patch path so GMSA contents are inlined at the correct location for init containers (`/spec/initContainers/%d/...` instead of a pod-level path).
- Fixes the update-validation webhook's lookup of a pod's previous GMSA settings so it correctly picks up prior init container state (previously only regular containers were captured).
- Extends the existing shared test harness (`runWebhookValidateOrMutateTests`) to also exercise init containers, so every existing create/mutate/update positive and negative test case now runs against init containers as well as pod- and container-level settings.

## Testing

- `go build ./...`
- `go vet ./...`
- `gofmt -l` on all changed files (clean)
- `go test ./admission-webhook/...` (unit tests) — all passing, including new init-container coverage across `TestValidateCreateRequest`, `TestMutateCreateRequest`, and `TestValidateUpdateRequest`.