### PR TITLE
Use current gcb-docker-gcloud builder image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name:  'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230522-312425ae46'
+  - name:  'registry.k8s.io/releng/gcb-docker-gcloud:v20260806'
     entrypoint: bash
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
the old one is deprecated and no longer available